### PR TITLE
Force git version rebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ DMRGateway:	GitVersion.h $(OBJECTS)
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
+.PHONY: GitVersion.h
+
 clean:
 		$(RM) DMRGateway *.o *.d *.bak *~ GitVersion.h
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,11 @@ DMRGateway:	GitVersion.h $(OBJECTS)
 %.o: %.cpp
 		$(CXX) $(CFLAGS) -c -o $@ $<
 
+DMRGateway.o: GitVersion.h FORCE
+
 .PHONY: GitVersion.h
+
+FORCE:
 
 clean:
 		$(RM) DMRGateway *.o *.d *.bak *~ GitVersion.h


### PR DESCRIPTION
As of now the git version only gets refreshed after a "make clean". If you just do a "git pull" to fetch recent changes and "make" it will still say it is the former git version. This should force to always rebuild GitVersion.h and thus DMRGateway.o in order to contain the latest git ID.

@m1geo Maybe you could test it?