### PR TITLE
XLX: add unlink before re-link

### DIFF
--- a/DMRGateway.cpp
+++ b/DMRGateway.cpp
@@ -414,6 +414,9 @@ int CDMRGateway::run()
 				m_xlx1Reflector = 4000U;
 				m_xlx1Connected = false;
 			} else if (connected && m_xlx1Relink && xlx1LastSeenTime && (unsigned(time(NULL)) - unsigned(xlx1LastSeenTime)) > (m_xlx1Relink*60) && m_xlx1Reflector != m_xlx1Startup) {
+				if (m_xlx1Startup != 4000U) {
+				      writeXLXLink(m_xlx1Id,4000U,m_xlxNetwork1);
+				}
 				writeXLXLink(m_xlx1Id,m_xlx1Startup,m_xlxNetwork1);
 				LogMessage("XLX-1, Re-linking to startup reflector %u due to RF inactivity timeout (%u minutes)", m_xlx1Startup, m_xlx1Relink);
 				m_xlx1Reflector = m_xlx1Startup;
@@ -449,7 +452,10 @@ int CDMRGateway::run()
 				m_xlx2Reflector = 4000U;
 				m_xlx2Connected = false;
 			} else if (connected && m_xlx2Relink && xlx2LastSeenTime && (unsigned(time(NULL)) - unsigned(xlx2LastSeenTime)) > (m_xlx2Relink*60) && m_xlx2Reflector != m_xlx2Startup) {
-                                writeXLXLink(m_xlx2Id,m_xlx2Startup,m_xlxNetwork2);
+                                if (m_xlx2Startup != 4000U) {
+				      writeXLXLink(m_xlx2Id,4000U,m_xlxNetwork2);
+				}
+				writeXLXLink(m_xlx2Id,m_xlx2Startup,m_xlxNetwork2);
                                 LogMessage("XLX-2, Re-linking to startup reflector %u due to RF inactivity timeout (%u minutes)", m_xlx2Startup, m_xlx2Relink);
 				m_xlx2Reflector = m_xlx2Startup;
 				if (voice1 != NULL) {


### PR DESCRIPTION
An unlink appears to be required by the XLX reflector before we are able to re-link to another reflector. 