### PR TITLE
Suppress smae TGs in rule tracer

### DIFF
--- a/RewriteTG.cpp
+++ b/RewriteTG.cpp
@@ -51,8 +51,12 @@ bool CRewriteTG::process(CDMRData& data, bool trace)
 	unsigned int slotNo = data.getSlotNo();
 
 	if (flco != FLCO_GROUP || slotNo != m_fromSlot || dstId < m_fromTGStart || dstId > m_fromTGEnd) {
-		if (trace)
-			LogDebug("Rule Trace,\tRewriteTG from %s Slot=%u Dst=TG%u-TG%u: not matched", m_name, m_fromSlot, m_fromTGStart, m_fromTGEnd);
+		if (trace) {
+			if (m_fromTGStart == m_fromTGEnd)
+				LogDebug("Rule Trace,\tRewriteTG from %s Slot=%u Dst=TG%u: not matched", m_name, m_fromSlot, m_fromTGStart);
+			else
+				LogDebug("Rule Trace,\tRewriteTG from %s Slot=%u Dst=TG%u-TG%u: not matched", m_name, m_fromSlot, m_fromTGStart, m_fromTGEnd);
+		}
 		return false;
 	}
 
@@ -84,8 +88,14 @@ bool CRewriteTG::process(CDMRData& data, bool trace)
 	}
 
 	if (trace) {
-		LogDebug("Rule Trace,\tRewriteTG from %s Slot=%u Dst=TG%u-TG%u: matched", m_name, m_fromSlot, m_fromTGStart, m_fromTGEnd);
-		LogDebug("Rule Trace,\tRewriteTG to %s Slot=%u Dst=TG%u-TG%u", m_name, m_toSlot, m_toTGStart, m_toTGEnd);
+		if (m_fromTGStart == m_fromTGEnd)
+			LogDebug("Rule Trace,\tRewriteTG from %s Slot=%u Dst=TG%u: matched", m_name, m_fromSlot, m_fromTGStart);
+		else
+			LogDebug("Rule Trace,\tRewriteTG from %s Slot=%u Dst=TG%u-TG%u: matched", m_name, m_fromSlot, m_fromTGStart, m_fromTGEnd);
+		if (m_toTGStart == m_toTGEnd)
+			LogDebug("Rule Trace,\tRewriteTG to %s Slot=%u Dst=TG%u", m_name, m_toSlot, m_toTGStart);
+		else
+			LogDebug("Rule Trace,\tRewriteTG to %s Slot=%u Dst=TG%u-TG%u", m_name, m_toSlot, m_toTGStart, m_toTGEnd);
 	}
 
 	return true;


### PR DESCRIPTION
Just a bit of beauty for the rule tracer: Suppress the toTG information if only one TGs in logged. 