### PR TITLE
Simplification of DMRGateway.ini

### DIFF
--- a/DMRGateway.ini
+++ b/DMRGateway.ini
@@ -48,49 +48,33 @@ Startup=950
 Relink=10
 Debug=0
 
-# BrandMeister
+#DMRPlus
 [DMR Network 1]
-Enabled=0
-Name=BM
-Address=44.131.4.1
-Port=62031
-# Local=3352
-# Local cluster
-TGRewrite=1,9,1,9,1
-# Reflector TG on to slot 2 TG9
-TGRewrite=2,9,2,9,1
-# Reflector control command slot 2 94000->4000 to 95000->5000
-PCRewrite=2,94000,2,4000,1001
-# Echo on RF slot 1 TG9990 to network slot 1 9990
-TypeRewrite=1,9990,1,9990
-SrcRewrite=1,9990,1,9990,1
-# Reflector status returns
-SrcRewrite=2,4000,2,9,1001
-# Pass all of the other private traffic on slot 1 and slot 2
+Enabled=1
+Address=[ip or url of dmrplus master or IPSC server]
+Port=55555
+Local=62030
+Jitter=100
+# TG Routing fromRFSlot, fromRFTG, toMasterSlot, toMasterTG, range
+TGRewrite=1,9,2,9,1
+# Reflector Control remap
+TGRewrite=1,4000,2,4000,1001
+PCRewrite=1,4000,2,4000,1001
+PassAllTG=1
 PassAllPC=1
-PassAllPC=2
 Password=PASSWORD
-Location=1
 Debug=0
 
-# DMR+
+#Brandmeister
 [DMR Network 2]
-Enabled=0
-Name=DMR+
-Address=44.131.4.1
-Port=55555
-# Local=3352
-# Reflector TG on to slot 2 TG8
-TGRewrite=2,8,2,9,1
-# Echo on slot 2 TG9990
-TGRewrite=2,9990,2,9990,1
-# Reflector control command slot 2 84000->4000 to 85000->5000
-PCRewrite=2,84000,2,4000,1001
-# Pass all of the other talk group traffic on slot 1 and slot 2
-PassAllTG=1
+Enabled=1
+Address=[ip or url of Brandmeister master]
+Port=62031
+Jitter=100
+Local=62031
 PassAllTG=2
-Password=PASSWORD
-Location=0
+PassAllPC=2
+Password=passw0rd
 Debug=0
 
 # Local HBLink network


### PR DESCRIPTION
This configuration assigns TS1 to DMRPlus/IPSC and TS2 to Brandmeister. DMRPlus Reflectors are on TS1 TG9. TS1 has to be empty in Brandmeister selfcare. In my opinion this is the simplest way use DMRGateway. Many configurations I encountered are using complex Talkgroup "NAT", so before I was able to make a contact I always had to search for a documentation of the one specific repeater I am using. In this configuration a single call to 5000 or the RPT-Command at 262994 tells me everything I need to know.