### PR TITLE
Add optional config option to override default module for startup reflector. 

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -126,7 +126,8 @@ m_xlxNetworkTG(8U),
 m_xlxNetworkBase(84000U),
 m_xlxNetworkStartup(4000U),
 m_xlxNetworkRelink(0U),
-m_xlxNetworkDebug(false)
+m_xlxNetworkDebug(false),
+m_xlxNetworkUserControl(true)
 {
 }
 
@@ -272,6 +273,8 @@ bool CConf::read()
 				m_xlxNetworkRelink = (unsigned int)::atoi(value);
 			else if (::strcmp(key, "Debug") == 0)
 				m_xlxNetworkDebug = ::atoi(value) == 1;
+            else if (::strcmp(key, "UserControl") == 0)
+                m_xlxNetworkUserControl = atoi(value) ==1;
 		} else if (section == SECTION_DMR_NETWORK_1) {
 			if (::strcmp(key, "Enabled") == 0)
 				m_dmrNetwork1Enabled = ::atoi(value) == 1;
@@ -731,6 +734,10 @@ unsigned int CConf::getXLXNetworkRelink() const
 bool CConf::getXLXNetworkDebug() const
 {
 	return m_xlxNetworkDebug;
+}
+bool CConf::getXLXNetworkUserControl() const
+{
+	return m_xlxNetworkUserControl;
 }
 
 bool CConf::getDMRNetwork1Enabled() const

--- a/Conf.cpp
+++ b/Conf.cpp
@@ -127,7 +127,8 @@ m_xlxNetworkBase(84000U),
 m_xlxNetworkStartup(4000U),
 m_xlxNetworkRelink(0U),
 m_xlxNetworkDebug(false),
-m_xlxNetworkUserControl(true)
+m_xlxNetworkUserControl(true),
+m_xlxNetworkModule()
 {
 }
 
@@ -274,7 +275,9 @@ bool CConf::read()
 			else if (::strcmp(key, "Debug") == 0)
 				m_xlxNetworkDebug = ::atoi(value) == 1;
             else if (::strcmp(key, "UserControl") == 0)
-                m_xlxNetworkUserControl = atoi(value) ==1;
+                m_xlxNetworkUserControl = ::atoi(value) ==1;
+            else if (::strcmp(key, "Module") == 0)
+                m_xlxNetworkModule = value[0];
 		} else if (section == SECTION_DMR_NETWORK_1) {
 			if (::strcmp(key, "Enabled") == 0)
 				m_dmrNetwork1Enabled = ::atoi(value) == 1;
@@ -738,6 +741,10 @@ bool CConf::getXLXNetworkDebug() const
 bool CConf::getXLXNetworkUserControl() const
 {
 	return m_xlxNetworkUserControl;
+}
+char CConf::getXLXNetworkModule() const
+{
+	return m_xlxNetworkModule;
 }
 
 bool CConf::getDMRNetwork1Enabled() const

--- a/Conf.cpp
+++ b/Conf.cpp
@@ -277,7 +277,7 @@ bool CConf::read()
             else if (::strcmp(key, "UserControl") == 0)
                 m_xlxNetworkUserControl = ::atoi(value) ==1;
             else if (::strcmp(key, "Module") == 0)
-                m_xlxNetworkModule = value[0];
+                m_xlxNetworkModule = ::toupper(value[0]);
 		} else if (section == SECTION_DMR_NETWORK_1) {
 			if (::strcmp(key, "Enabled") == 0)
 				m_dmrNetwork1Enabled = ::atoi(value) == 1;

--- a/Conf.h
+++ b/Conf.h
@@ -163,6 +163,7 @@ public:
 	unsigned int getXLXNetworkStartup() const;
 	unsigned int getXLXNetworkRelink() const;
 	bool         getXLXNetworkDebug() const;
+    bool         getXLXNetworkUserControl() const;
 
 private:
 	std::string  m_file;
@@ -260,6 +261,7 @@ private:
 	unsigned int m_xlxNetworkStartup;
 	unsigned int m_xlxNetworkRelink;
 	bool         m_xlxNetworkDebug;
+    bool         m_xlxNetworkUserControl;
 };
 
 #endif

--- a/Conf.h
+++ b/Conf.h
@@ -164,6 +164,7 @@ public:
 	unsigned int getXLXNetworkRelink() const;
 	bool         getXLXNetworkDebug() const;
     bool         getXLXNetworkUserControl() const;
+    char         getXLXNetworkModule() const;
 
 private:
 	std::string  m_file;
@@ -262,6 +263,7 @@ private:
 	unsigned int m_xlxNetworkRelink;
 	bool         m_xlxNetworkDebug;
     bool         m_xlxNetworkUserControl;
+    char         m_xlxNetworkModule;
 };
 
 #endif

--- a/DMRGateway.cpp
+++ b/DMRGateway.cpp
@@ -1460,7 +1460,7 @@ bool CDMRGateway::linkXLX(unsigned int number)
 
 	m_xlxNumber    = number;
     if (m_xlxModule) {
-        m_xlxRoom  = (int(m_xlxModule) - 94);
+        m_xlxRoom  = ((int(m_xlxModule) - 94U) + 4000U);
     } else {
         m_xlxRoom      = reflector->m_startup;
     }

--- a/DMRGateway.cpp
+++ b/DMRGateway.cpp
@@ -1460,7 +1460,7 @@ bool CDMRGateway::linkXLX(unsigned int number)
 
 	m_xlxNumber    = number;
     if (m_xlxModule) {
-        m_xlxRoom  = ((int(m_xlxModule) - 94U) + 4000U);
+        m_xlxRoom  = ((int(m_xlxModule) - 64U) + 4000U);
     } else {
         m_xlxRoom      = reflector->m_startup;
     }

--- a/DMRGateway.cpp
+++ b/DMRGateway.cpp
@@ -156,6 +156,7 @@ m_xlxRoom(4000U),
 m_xlxRelink(1000U),
 m_xlxConnected(false),
 m_xlxDebug(false),
+m_xlxUserControl(true),
 m_rptRewrite(NULL),
 m_xlxRewrite(NULL),
 m_dmr1NetRewrites(),
@@ -483,7 +484,7 @@ int CDMRGateway::run()
 				status[slotNo] = DMRGWS_XLXREFLECTOR;
 				timer[slotNo]->setTimeout(rfTimeout);
 				timer[slotNo]->start();
-			} else if ((dstId <= (m_xlxBase + 26U) || dstId == (m_xlxBase + 1000U)) && flco == FLCO_USER_USER && slotNo == m_xlxSlot && dstId >= m_xlxBase) {
+			} else if ((dstId <= (m_xlxBase + 26U) || dstId == (m_xlxBase + 1000U)) && flco == FLCO_USER_USER && slotNo == m_xlxSlot && dstId >= m_xlxBase && m_xlxUserControl) {
 				dstId += 4000U;
 				dstId -= m_xlxBase;
 
@@ -525,7 +526,7 @@ int CDMRGateway::run()
 						}
 					}
 				}
-			} else if (dstId >= (m_xlxBase + 4000U) && dstId < (m_xlxBase + 5000U) && flco == FLCO_USER_USER && slotNo == m_xlxSlot) {
+			} else if (dstId >= (m_xlxBase + 4000U) && dstId < (m_xlxBase + 5000U) && flco == FLCO_USER_USER && slotNo == m_xlxSlot && m_xlxUserControl) {
 				dstId -= 4000U;
 				dstId -= m_xlxBase;
 
@@ -1370,11 +1371,12 @@ bool CDMRGateway::createXLXNetwork()
 		return false;
 	}
 
-	m_xlxLocal    = m_conf.getXLXNetworkLocal();
-    m_xlxPort     = m_conf.getXLXNetworkPort();
-    m_xlxPassword = m_conf.getXLXNetworkPassword();
-    m_xlxId       = m_conf.getXLXNetworkId();
-	m_xlxDebug    = m_conf.getXLXNetworkDebug();
+	m_xlxLocal         = m_conf.getXLXNetworkLocal();
+    m_xlxPort          = m_conf.getXLXNetworkPort();
+    m_xlxPassword      = m_conf.getXLXNetworkPassword();
+    m_xlxId            = m_conf.getXLXNetworkId();
+	m_xlxDebug         = m_conf.getXLXNetworkDebug();
+    m_xlxUserControl   = m_conf.getXLXNetworkUserControl();
 
 	if (m_xlxId == 0U)
 		m_xlxId = m_repeater->getId();
@@ -1406,6 +1408,12 @@ bool CDMRGateway::createXLXNetwork()
 	} else {
 		LogInfo("    Relink: disabled");
 	}
+	if (m_xlxUserControl) {
+        LogInfo("    User Control: enabled");
+    } else {
+        LogInfo("    User Control: disabled");
+    }
+    
 
 	if (m_xlxStartup > 0U)
 		linkXLX(m_xlxStartup);

--- a/DMRGateway.cpp
+++ b/DMRGateway.cpp
@@ -157,6 +157,7 @@ m_xlxRelink(1000U),
 m_xlxConnected(false),
 m_xlxDebug(false),
 m_xlxUserControl(true),
+m_xlxModule(),
 m_rptRewrite(NULL),
 m_xlxRewrite(NULL),
 m_dmr1NetRewrites(),
@@ -1385,6 +1386,7 @@ bool CDMRGateway::createXLXNetwork()
 	m_xlxTG      = m_conf.getXLXNetworkTG();
 	m_xlxBase    = m_conf.getXLXNetworkBase();
 	m_xlxStartup = m_conf.getXLXNetworkStartup();
+    m_xlxModule  = m_conf.getXLXNetworkModule();
 
 	unsigned int xlxRelink  = m_conf.getXLXNetworkRelink();
 
@@ -1412,6 +1414,9 @@ bool CDMRGateway::createXLXNetwork()
         LogInfo("    User Control: enabled");
     } else {
         LogInfo("    User Control: disabled");
+    }
+    if (m_xlxModule) {
+        LogInfo("     Module: %c",m_xlxModule);
     }
     
 
@@ -1454,7 +1459,11 @@ bool CDMRGateway::linkXLX(unsigned int number)
 	}
 
 	m_xlxNumber    = number;
-	m_xlxRoom      = reflector->m_startup;
+    if (m_xlxModule) {
+        m_xlxRoom  = (int(m_xlxModule) - 94);
+    } else {
+        m_xlxRoom      = reflector->m_startup;
+    }
 	m_xlxReflector = 4000U;
 
 	LogMessage("XLX, Connecting to XLX%03u", m_xlxNumber);

--- a/DMRGateway.h
+++ b/DMRGateway.h
@@ -66,6 +66,7 @@ private:
 	bool               m_xlxConnected;
 	bool               m_xlxDebug;
     bool               m_xlxUserControl;
+    char               m_xlxModule;
 	CRewriteTG*        m_rptRewrite;
 	CRewriteTG*        m_xlxRewrite;
 	std::vector<CRewrite*> m_dmr1NetRewrites;

--- a/DMRGateway.h
+++ b/DMRGateway.h
@@ -65,6 +65,7 @@ private:
 	CTimer 	           m_xlxRelink;
 	bool               m_xlxConnected;
 	bool               m_xlxDebug;
+    bool               m_xlxUserControl;
 	CRewriteTG*        m_rptRewrite;
 	CRewriteTG*        m_xlxRewrite;
 	std::vector<CRewrite*> m_dmr1NetRewrites;

--- a/DMRGateway.ini
+++ b/DMRGateway.ini
@@ -47,7 +47,10 @@ Base=64000
 Startup=950
 Relink=10
 Debug=0
+#Allow user linking control using Private Calls
 UserControl=1
+#Override default module for startup reflector
+#Module=A
 
 # BrandMeister
 [DMR Network 1]

--- a/DMRGateway.ini
+++ b/DMRGateway.ini
@@ -47,6 +47,7 @@ Base=64000
 Startup=950
 Relink=10
 Debug=0
+UserControl=1
 
 # BrandMeister
 [DMR Network 1]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC      = gcc
 CXX     = g++
-CFLAGS  = -g -O3 -Wall -std=c++0x -pthread
+CFLAGS  = -g -O3 -Wall -std=c++0x -pthread -lrt
 LIBS    = -lpthread
 LDFLAGS = -g
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC      = gcc
 CXX     = g++
-CFLAGS  = -g -O3 -Wall -std=c++0x -pthread -lrt
+CFLAGS  = -g -O3 -Wall -std=c++0x -pthread
 LIBS    = -lpthread
 LDFLAGS = -g
 


### PR DESCRIPTION
Added "Module=[A..Z]" to XLX section of config file. 
If this option exists the default module with be over-ridden with the module specified for the startup reflector. 

Added example to DMRGateway.ini