### PR TITLE
RF Id <-> Network Id Translation

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -81,6 +81,7 @@ m_dmrNetwork1TGRewrites(),
 m_dmrNetwork1PCRewrites(),
 m_dmrNetwork1TypeRewrites(),
 m_dmrNetwork1SrcRewrites(),
+m_dmrNetwork1IdRewrites(),
 m_dmrNetwork1PassAllPC(),
 m_dmrNetwork1PassAllTG(),
 m_dmrNetwork2Enabled(false),
@@ -97,6 +98,7 @@ m_dmrNetwork2TGRewrites(),
 m_dmrNetwork2PCRewrites(),
 m_dmrNetwork2TypeRewrites(),
 m_dmrNetwork2SrcRewrites(),
+m_dmrNetwork2IdRewrites(),
 m_dmrNetwork2PassAllPC(),
 m_dmrNetwork2PassAllTG(),
 m_dmrNetwork3Enabled(false),
@@ -113,6 +115,7 @@ m_dmrNetwork3TGRewrites(),
 m_dmrNetwork3PCRewrites(),
 m_dmrNetwork3TypeRewrites(),
 m_dmrNetwork3SrcRewrites(),
+m_dmrNetwork3IdRewrites(),
 m_dmrNetwork3PassAllPC(),
 m_dmrNetwork3PassAllTG(),
 m_dmrNetwork4Enabled(false),
@@ -129,6 +132,7 @@ m_dmrNetwork4TGRewrites(),
 m_dmrNetwork4PCRewrites(),
 m_dmrNetwork4TypeRewrites(),
 m_dmrNetwork4SrcRewrites(),
+m_dmrNetwork4IdRewrites(),
 m_dmrNetwork4PassAllPC(),
 m_dmrNetwork4PassAllTG(),
 m_xlxNetworkEnabled(false),
@@ -376,6 +380,15 @@ bool CConf::read()
 					rewrite.m_range    = ::atoi(p5);
 					m_dmrNetwork1SrcRewrites.push_back(rewrite);
 				}
+			} else if (::strncmp(key, "IdRewrite", 9U) == 0) {
+				char* rfId = ::strtok(value, ", ");
+				char* netId = ::strtok(NULL, " \r\n");
+				if (rfId != NULL && netId != NULL) {
+					CIdRewriteStruct rewrite;
+					rewrite.m_rfId  = ::atoi(rfId);
+					rewrite.m_netId = ::atoi(netId);
+					m_dmrNetwork1IdRewrites.push_back(rewrite);
+				}
 			} else if (::strncmp(key, "PassAllPC", 9U) == 0) {
 				unsigned int slotNo = (unsigned int)::atoi(value);
 				m_dmrNetwork1PassAllPC.push_back(slotNo);
@@ -461,6 +474,15 @@ bool CConf::read()
 					rewrite.m_toTG     = ::atoi(p4);
 					rewrite.m_range    = ::atoi(p5);
 					m_dmrNetwork2SrcRewrites.push_back(rewrite);
+				}
+			} else if (::strncmp(key, "IdRewrite", 9U) == 0) {
+				char* rfId = ::strtok(value, ", ");
+				char* netId = ::strtok(NULL, " \r\n");
+				if (rfId != NULL && netId != NULL) {
+					CIdRewriteStruct rewrite;
+					rewrite.m_rfId  = ::atoi(rfId);
+					rewrite.m_netId = ::atoi(netId);
+					m_dmrNetwork2IdRewrites.push_back(rewrite);
 				}
 			} else if (::strncmp(key, "PassAllPC", 9U) == 0) {
 				unsigned int slotNo = (unsigned int)::atoi(value);
@@ -548,6 +570,15 @@ bool CConf::read()
 					rewrite.m_range    = ::atoi(p5);
 					m_dmrNetwork3SrcRewrites.push_back(rewrite);
 				}
+			} else if (::strncmp(key, "IdRewrite", 9U) == 0) {
+				char* rfId = ::strtok(value, ", ");
+				char* netId = ::strtok(NULL, " \r\n");
+				if (rfId != NULL && netId != NULL) {
+					CIdRewriteStruct rewrite;
+					rewrite.m_rfId  = ::atoi(rfId);
+					rewrite.m_netId = ::atoi(netId);
+					m_dmrNetwork3IdRewrites.push_back(rewrite);
+				}
 			} else if (::strncmp(key, "PassAllPC", 9U) == 0) {
 				unsigned int slotNo = (unsigned int)::atoi(value);
 				m_dmrNetwork3PassAllPC.push_back(slotNo);
@@ -633,6 +664,15 @@ bool CConf::read()
 					rewrite.m_toTG     = ::atoi(p4);
 					rewrite.m_range    = ::atoi(p5);
 					m_dmrNetwork4SrcRewrites.push_back(rewrite);
+				}
+			} else if (::strncmp(key, "IdRewrite", 9U) == 0) {
+				char* rfId = ::strtok(value, ", ");
+				char* netId = ::strtok(NULL, " \r\n");
+				if (rfId != NULL && netId != NULL) {
+					CIdRewriteStruct rewrite;
+					rewrite.m_rfId  = ::atoi(rfId);
+					rewrite.m_netId = ::atoi(netId);
+					m_dmrNetwork4IdRewrites.push_back(rewrite);
 				}
 			} else if (::strncmp(key, "PassAllPC", 9U) == 0) {
 				unsigned int slotNo = (unsigned int)::atoi(value);
@@ -925,6 +965,11 @@ std::vector<CSrcRewriteStruct> CConf::getDMRNetwork1SrcRewrites() const
 	return m_dmrNetwork1SrcRewrites;
 }
 
+std::vector<CIdRewriteStruct> CConf::getDMRNetwork1IdRewrites() const
+{
+	return m_dmrNetwork1IdRewrites;
+}
+
 std::vector<unsigned int> CConf::getDMRNetwork1PassAllPC() const
 {
 	return m_dmrNetwork1PassAllPC;
@@ -1006,6 +1051,11 @@ std::vector<CTypeRewriteStruct> CConf::getDMRNetwork2TypeRewrites() const
 std::vector<CSrcRewriteStruct> CConf::getDMRNetwork2SrcRewrites() const
 {
 	return m_dmrNetwork2SrcRewrites;
+}
+
+std::vector<CIdRewriteStruct> CConf::getDMRNetwork2IdRewrites() const
+{
+	return m_dmrNetwork2IdRewrites;
 }
 
 std::vector<unsigned int> CConf::getDMRNetwork2PassAllPC() const
@@ -1091,6 +1141,11 @@ std::vector<CSrcRewriteStruct> CConf::getDMRNetwork3SrcRewrites() const
 	return m_dmrNetwork3SrcRewrites;
 }
 
+std::vector<CIdRewriteStruct> CConf::getDMRNetwork3IdRewrites() const
+{
+	return m_dmrNetwork3IdRewrites;
+}
+
 std::vector<unsigned int> CConf::getDMRNetwork3PassAllPC() const
 {
 	return m_dmrNetwork3PassAllPC;
@@ -1172,6 +1227,11 @@ std::vector<CTypeRewriteStruct> CConf::getDMRNetwork4TypeRewrites() const
 std::vector<CSrcRewriteStruct> CConf::getDMRNetwork4SrcRewrites() const
 {
 	return m_dmrNetwork4SrcRewrites;
+}
+
+std::vector<CIdRewriteStruct> CConf::getDMRNetwork4IdRewrites() const
+{
+	return m_dmrNetwork4IdRewrites;
 }
 
 std::vector<unsigned int> CConf::getDMRNetwork4PassAllPC() const

--- a/Conf.h
+++ b/Conf.h
@@ -53,6 +53,11 @@ struct CSrcRewriteStruct {
 	unsigned int m_range;
 };
 
+struct CIdRewriteStruct {
+	unsigned int m_rfId;
+	unsigned int m_netId;
+};
+
 class CConf
 {
 public:
@@ -110,6 +115,7 @@ public:
 	std::vector<CPCRewriteStruct>   getDMRNetwork1PCRewrites() const;
 	std::vector<CTypeRewriteStruct> getDMRNetwork1TypeRewrites() const;
 	std::vector<CSrcRewriteStruct>  getDMRNetwork1SrcRewrites() const;
+	std::vector<CIdRewriteStruct>  getDMRNetwork1IdRewrites() const;
 	std::vector<unsigned int>       getDMRNetwork1PassAllPC() const;
 	std::vector<unsigned int>       getDMRNetwork1PassAllTG() const;
 
@@ -128,6 +134,7 @@ public:
 	std::vector<CPCRewriteStruct>   getDMRNetwork2PCRewrites() const;
 	std::vector<CTypeRewriteStruct> getDMRNetwork2TypeRewrites() const;
 	std::vector<CSrcRewriteStruct>  getDMRNetwork2SrcRewrites() const;
+	std::vector<CIdRewriteStruct>  getDMRNetwork2IdRewrites() const;
 	std::vector<unsigned int>       getDMRNetwork2PassAllPC() const;
 	std::vector<unsigned int>       getDMRNetwork2PassAllTG() const;
 
@@ -146,6 +153,7 @@ public:
 	std::vector<CPCRewriteStruct>   getDMRNetwork3PCRewrites() const;
 	std::vector<CTypeRewriteStruct> getDMRNetwork3TypeRewrites() const;
 	std::vector<CSrcRewriteStruct>  getDMRNetwork3SrcRewrites() const;
+	std::vector<CIdRewriteStruct>  getDMRNetwork3IdRewrites() const;
 	std::vector<unsigned int>       getDMRNetwork3PassAllPC() const;
 	std::vector<unsigned int>       getDMRNetwork3PassAllTG() const;
 
@@ -164,6 +172,7 @@ public:
 	std::vector<CPCRewriteStruct>   getDMRNetwork4PCRewrites() const;
 	std::vector<CTypeRewriteStruct> getDMRNetwork4TypeRewrites() const;
 	std::vector<CSrcRewriteStruct>  getDMRNetwork4SrcRewrites() const;
+	std::vector<CIdRewriteStruct>  getDMRNetwork4IdRewrites() const;
 	std::vector<unsigned int>       getDMRNetwork4PassAllPC() const;
 	std::vector<unsigned int>       getDMRNetwork4PassAllTG() const;
 
@@ -230,6 +239,7 @@ private:
 	std::vector<CPCRewriteStruct>   m_dmrNetwork1PCRewrites;
 	std::vector<CTypeRewriteStruct> m_dmrNetwork1TypeRewrites;
 	std::vector<CSrcRewriteStruct>  m_dmrNetwork1SrcRewrites;
+	std::vector<CIdRewriteStruct>  m_dmrNetwork1IdRewrites;
 	std::vector<unsigned int>       m_dmrNetwork1PassAllPC;
 	std::vector<unsigned int>       m_dmrNetwork1PassAllTG;
 
@@ -247,6 +257,7 @@ private:
 	std::vector<CPCRewriteStruct>   m_dmrNetwork2PCRewrites;
 	std::vector<CTypeRewriteStruct> m_dmrNetwork2TypeRewrites;
 	std::vector<CSrcRewriteStruct>  m_dmrNetwork2SrcRewrites;
+	std::vector<CIdRewriteStruct>  m_dmrNetwork2IdRewrites;
 	std::vector<unsigned int>       m_dmrNetwork2PassAllPC;
 	std::vector<unsigned int>       m_dmrNetwork2PassAllTG;
 
@@ -264,6 +275,7 @@ private:
 	std::vector<CPCRewriteStruct>   m_dmrNetwork3PCRewrites;
 	std::vector<CTypeRewriteStruct> m_dmrNetwork3TypeRewrites;
 	std::vector<CSrcRewriteStruct>  m_dmrNetwork3SrcRewrites;
+	std::vector<CIdRewriteStruct>  m_dmrNetwork3IdRewrites;
 	std::vector<unsigned int>       m_dmrNetwork3PassAllPC;
 	std::vector<unsigned int>       m_dmrNetwork3PassAllTG;
 
@@ -281,6 +293,7 @@ private:
 	std::vector<CPCRewriteStruct>   m_dmrNetwork4PCRewrites;
 	std::vector<CTypeRewriteStruct> m_dmrNetwork4TypeRewrites;
 	std::vector<CSrcRewriteStruct>  m_dmrNetwork4SrcRewrites;
+	std::vector<CIdRewriteStruct>  m_dmrNetwork4IdRewrites;
 	std::vector<unsigned int>       m_dmrNetwork4PassAllPC;
 	std::vector<unsigned int>       m_dmrNetwork4PassAllTG;
 

--- a/DMRGateway.cpp
+++ b/DMRGateway.cpp
@@ -22,6 +22,8 @@
 #include "DMRGateway.h"
 #include "StopWatch.h"
 #include "RewritePC.h"
+#include "RewriteSrcId.h"
+#include "RewriteDstId.h"
 #include "PassAllPC.h"
 #include "PassAllTG.h"
 #include "DMRFullLC.h"
@@ -165,10 +167,16 @@ m_rptRewrite(NULL),
 m_xlxRewrite(NULL),
 m_dmr1NetRewrites(),
 m_dmr1RFRewrites(),
+m_dmr1SrcRewrites(),
 m_dmr2NetRewrites(),
 m_dmr2RFRewrites(),
+m_dmr2SrcRewrites(),
 m_dmr3NetRewrites(),
 m_dmr3RFRewrites(),
+m_dmr3SrcRewrites(),
+m_dmr4NetRewrites(),
+m_dmr4RFRewrites(),
+m_dmr4SrcRewrites(),
 m_dmr1Passalls(),
 m_dmr2Passalls(),
 m_dmr3Passalls()
@@ -184,16 +192,34 @@ CDMRGateway::~CDMRGateway()
 	for (std::vector<CRewrite*>::iterator it = m_dmr1RFRewrites.begin(); it != m_dmr1RFRewrites.end(); ++it)
 		delete *it;
 
+	for (std::vector<CRewrite*>::iterator it = m_dmr1SrcRewrites.begin(); it != m_dmr1SrcRewrites.end(); ++it)
+		delete *it;
+
 	for (std::vector<CRewrite*>::iterator it = m_dmr2NetRewrites.begin(); it != m_dmr2NetRewrites.end(); ++it)
 			delete *it;
 	
 	for (std::vector<CRewrite*>::iterator it = m_dmr2RFRewrites.begin(); it != m_dmr2RFRewrites.end(); ++it)
 			delete *it;
 
+	for (std::vector<CRewrite*>::iterator it = m_dmr2SrcRewrites.begin(); it != m_dmr2SrcRewrites.end(); ++it)
+		delete *it;
+
 	for (std::vector<CRewrite*>::iterator it = m_dmr3NetRewrites.begin(); it != m_dmr3NetRewrites.end(); ++it)
 		delete *it;
 
 	for (std::vector<CRewrite*>::iterator it = m_dmr3RFRewrites.begin(); it != m_dmr3RFRewrites.end(); ++it)
+		delete *it;
+
+	for (std::vector<CRewrite*>::iterator it = m_dmr3SrcRewrites.begin(); it != m_dmr3SrcRewrites.end(); ++it)
+		delete *it;
+
+	for (std::vector<CRewrite*>::iterator it = m_dmr4NetRewrites.begin(); it != m_dmr4NetRewrites.end(); ++it)
+		delete *it;
+
+	for (std::vector<CRewrite*>::iterator it = m_dmr4RFRewrites.begin(); it != m_dmr4RFRewrites.end(); ++it)
+		delete *it;
+
+	for (std::vector<CRewrite*>::iterator it = m_dmr4SrcRewrites.begin(); it != m_dmr4SrcRewrites.end(); ++it)
 		delete *it;
 
 	for (std::vector<CRewrite*>::iterator it = m_dmr1Passalls.begin(); it != m_dmr1Passalls.end(); ++it)
@@ -203,6 +229,9 @@ CDMRGateway::~CDMRGateway()
 		delete *it;
 
 	for (std::vector<CRewrite*>::iterator it = m_dmr3Passalls.begin(); it != m_dmr3Passalls.end(); ++it)
+		delete *it;
+
+	for (std::vector<CRewrite*>::iterator it = m_dmr4Passalls.begin(); it != m_dmr4Passalls.end(); ++it)
 		delete *it;
 
 	delete m_rptRewrite;
@@ -576,6 +605,7 @@ int CDMRGateway::run()
 
 					if (rewritten) {
 						if (status[slotNo] == DMRGWS_NONE || status[slotNo] == DMRGWS_DMRNETWORK1) {
+							rewrite(m_dmr1SrcRewrites, data, trace);
 							m_dmrNetwork1->write(data);
 							status[slotNo] = DMRGWS_DMRNETWORK1;
 							timer[slotNo]->setTimeout(rfTimeout);
@@ -597,6 +627,7 @@ int CDMRGateway::run()
 
 						if (rewritten) {
 							if (status[slotNo] == DMRGWS_NONE || status[slotNo] == DMRGWS_DMRNETWORK2) {
+								rewrite(m_dmr2SrcRewrites, data, trace);
 								m_dmrNetwork2->write(data);
 								status[slotNo] = DMRGWS_DMRNETWORK2;
 								timer[slotNo]->setTimeout(rfTimeout);
@@ -618,6 +649,7 @@ int CDMRGateway::run()
 
 							if (rewritten) {
 								if (status[slotNo] == DMRGWS_NONE || status[slotNo] == DMRGWS_DMRNETWORK3) {
+									rewrite(m_dmr3SrcRewrites, data, trace);
 									m_dmrNetwork3->write(data);
 									status[slotNo] = DMRGWS_DMRNETWORK3;
 									timer[slotNo]->setTimeout(rfTimeout);
@@ -639,6 +671,7 @@ int CDMRGateway::run()
 
 								if (rewritten) {
 									if (status[slotNo] == DMRGWS_NONE || status[slotNo] == DMRGWS_DMRNETWORK4) {
+										rewrite(m_dmr4SrcRewrites, data, trace);
 										m_dmrNetwork4->write(data);
 										status[slotNo] = DMRGWS_DMRNETWORK4;
 										timer[slotNo]->setTimeout(rfTimeout);
@@ -662,6 +695,7 @@ int CDMRGateway::run()
 
 						if (rewritten) {
 							if (status[slotNo] == DMRGWS_NONE || status[slotNo] == DMRGWS_DMRNETWORK1) {
+								rewrite(m_dmr1SrcRewrites, data, trace);
 								m_dmrNetwork1->write(data);
 								status[slotNo] = DMRGWS_DMRNETWORK1;
 								timer[slotNo]->setTimeout(rfTimeout);
@@ -683,6 +717,7 @@ int CDMRGateway::run()
 
 						if (rewritten) {
 							if (status[slotNo] == DMRGWS_NONE || status[slotNo] == DMRGWS_DMRNETWORK2) {
+								rewrite(m_dmr2SrcRewrites, data, trace);
 								m_dmrNetwork2->write(data);
 								status[slotNo] = DMRGWS_DMRNETWORK2;
 								timer[slotNo]->setTimeout(rfTimeout);
@@ -704,6 +739,7 @@ int CDMRGateway::run()
 
 						if (rewritten) {
 							if (status[slotNo] == DMRGWS_NONE || status[slotNo] == DMRGWS_DMRNETWORK3) {
+								rewrite(m_dmr3SrcRewrites, data, trace);
 								m_dmrNetwork3->write(data);
 								status[slotNo] = DMRGWS_DMRNETWORK3;
 								timer[slotNo]->setTimeout(rfTimeout);
@@ -725,6 +761,7 @@ int CDMRGateway::run()
 
 						if (rewritten) {
 							if (status[slotNo] == DMRGWS_NONE || status[slotNo] == DMRGWS_DMRNETWORK4) {
+								rewrite(m_dmr4SrcRewrites, data, trace);
 								m_dmrNetwork4->write(data);
 								status[slotNo] = DMRGWS_DMRNETWORK4;
 								timer[slotNo]->setTimeout(rfTimeout);
@@ -1209,6 +1246,17 @@ bool CDMRGateway::createDMRNetwork1()
 		m_dmr1NetRewrites.push_back(rewrite);
 	}
 
+	std::vector<CIdRewriteStruct> idRewrites = m_conf.getDMRNetwork1IdRewrites();
+	for (std::vector<CIdRewriteStruct>::const_iterator it = idRewrites.begin(); it != idRewrites.end(); ++it) {
+		LogInfo("    Rewrite Id: %u <-> %u", (*it).m_rfId, (*it).m_netId);
+
+		CRewriteSrcId* rewriteSrcId = new CRewriteSrcId(m_dmr1Name, (*it).m_rfId, (*it).m_netId);
+		CRewriteDstId* rewriteDstId = new CRewriteDstId(m_dmr1Name, (*it).m_netId, (*it).m_rfId);
+
+		m_dmr1SrcRewrites.push_back(rewriteSrcId);
+		m_dmr1NetRewrites.push_back(rewriteDstId);
+	}
+
 	std::vector<unsigned int> tgPassAll = m_conf.getDMRNetwork1PassAllTG();
 	for (std::vector<unsigned int>::const_iterator it = tgPassAll.begin(); it != tgPassAll.end(); ++it) {
 		LogInfo("    Pass All TG: %u", *it);
@@ -1334,6 +1382,17 @@ bool CDMRGateway::createDMRNetwork2()
 		CRewriteSrc* rewrite = new CRewriteSrc(m_dmr2Name, (*it).m_fromSlot, (*it).m_fromId, (*it).m_toSlot, (*it).m_toTG, (*it).m_range);
 
 		m_dmr2NetRewrites.push_back(rewrite);
+	}
+
+	std::vector<CIdRewriteStruct> idRewrites = m_conf.getDMRNetwork2IdRewrites();
+	for (std::vector<CIdRewriteStruct>::const_iterator it = idRewrites.begin(); it != idRewrites.end(); ++it) {
+		LogInfo("    Rewrite Id: %u <-> %u", (*it).m_rfId, (*it).m_netId);
+
+		CRewriteSrcId* rewriteSrcId = new CRewriteSrcId(m_dmr2Name, (*it).m_rfId, (*it).m_netId);
+		CRewriteDstId* rewriteDstId = new CRewriteDstId(m_dmr2Name, (*it).m_netId, (*it).m_rfId);
+
+		m_dmr2SrcRewrites.push_back(rewriteSrcId);
+		m_dmr2NetRewrites.push_back(rewriteDstId);
 	}
 
 	std::vector<unsigned int> tgPassAll = m_conf.getDMRNetwork2PassAllTG();
@@ -1463,6 +1522,17 @@ bool CDMRGateway::createDMRNetwork3()
 		m_dmr3NetRewrites.push_back(rewrite);
 	}
 
+	std::vector<CIdRewriteStruct> idRewrites = m_conf.getDMRNetwork3IdRewrites();
+	for (std::vector<CIdRewriteStruct>::const_iterator it = idRewrites.begin(); it != idRewrites.end(); ++it) {
+		LogInfo("    Rewrite Id: %u <-> %u", (*it).m_rfId, (*it).m_netId);
+
+		CRewriteSrcId* rewriteSrcId = new CRewriteSrcId(m_dmr3Name, (*it).m_rfId, (*it).m_netId);
+		CRewriteDstId* rewriteDstId = new CRewriteDstId(m_dmr3Name, (*it).m_netId, (*it).m_rfId);
+
+		m_dmr3SrcRewrites.push_back(rewriteSrcId);
+		m_dmr3NetRewrites.push_back(rewriteDstId);
+	}
+
 	std::vector<unsigned int> tgPassAll = m_conf.getDMRNetwork3PassAllTG();
 	for (std::vector<unsigned int>::const_iterator it = tgPassAll.begin(); it != tgPassAll.end(); ++it) {
 		LogInfo("    Pass All TG: %u", *it);
@@ -1588,6 +1658,17 @@ bool CDMRGateway::createDMRNetwork4()
 		CRewriteSrc* rewrite = new CRewriteSrc(m_dmr4Name, (*it).m_fromSlot, (*it).m_fromId, (*it).m_toSlot, (*it).m_toTG, (*it).m_range);
 
 		m_dmr4NetRewrites.push_back(rewrite);
+	}
+
+	std::vector<CIdRewriteStruct> idRewrites = m_conf.getDMRNetwork4IdRewrites();
+	for (std::vector<CIdRewriteStruct>::const_iterator it = idRewrites.begin(); it != idRewrites.end(); ++it) {
+		LogInfo("    Rewrite Id: %u <-> %u", (*it).m_rfId, (*it).m_netId);
+
+		CRewriteSrcId* rewriteSrcId = new CRewriteSrcId(m_dmr4Name, (*it).m_rfId, (*it).m_netId);
+		CRewriteDstId* rewriteDstId = new CRewriteDstId(m_dmr4Name, (*it).m_netId, (*it).m_rfId);
+
+		m_dmr4SrcRewrites.push_back(rewriteSrcId);
+		m_dmr4NetRewrites.push_back(rewriteDstId);
 	}
 
 	std::vector<unsigned int> tgPassAll = m_conf.getDMRNetwork4PassAllTG();
@@ -1792,6 +1873,14 @@ void CDMRGateway::writeXLXLink(unsigned int srcId, unsigned int dstId, CDMRNetwo
 		data.setSeqNo(i + 3U);
 		network->write(data);
 	}
+}
+
+bool CDMRGateway::rewrite(std::vector<CRewrite*>& rewrites, CDMRData & data, bool trace)
+{
+	for (std::vector<CRewrite*>::iterator it = rewrites.begin(); it != rewrites.end(); ++it)
+		if ((*it)->process(data, trace))
+			return true;
+	return false;
 }
 
 unsigned int CDMRGateway::getConfig(const std::string& name, unsigned char* buffer)

--- a/DMRGateway.h
+++ b/DMRGateway.h
@@ -73,12 +73,16 @@ private:
 	CRewriteTG*        m_xlxRewrite;
 	std::vector<CRewrite*> m_dmr1NetRewrites;
 	std::vector<CRewrite*> m_dmr1RFRewrites;
+	std::vector<CRewrite*> m_dmr1SrcRewrites;
 	std::vector<CRewrite*> m_dmr2NetRewrites;
 	std::vector<CRewrite*> m_dmr2RFRewrites;
+	std::vector<CRewrite*> m_dmr2SrcRewrites;
 	std::vector<CRewrite*> m_dmr3NetRewrites;
 	std::vector<CRewrite*> m_dmr3RFRewrites;
+	std::vector<CRewrite*> m_dmr3SrcRewrites;
 	std::vector<CRewrite*> m_dmr4NetRewrites;
 	std::vector<CRewrite*> m_dmr4RFRewrites;
+	std::vector<CRewrite*> m_dmr4SrcRewrites;
 	std::vector<CRewrite*> m_dmr1Passalls;
 	std::vector<CRewrite*> m_dmr2Passalls;
 	std::vector<CRewrite*> m_dmr3Passalls;
@@ -94,6 +98,8 @@ private:
 	bool linkXLX(unsigned int number);
 	void unlinkXLX();
 	void writeXLXLink(unsigned int srcId, unsigned int dstId, CDMRNetwork* network);
+
+	bool rewrite(std::vector<CRewrite*>& rewrites, CDMRData& data, bool trace);
 
 	unsigned int getConfig(const std::string& name, unsigned char* buffer);
 };

--- a/DMRGateway.vcxproj
+++ b/DMRGateway.vcxproj
@@ -176,8 +176,10 @@
     <ClInclude Include="Reflectors.h" />
     <ClInclude Include="RepeaterProtocol.h" />
     <ClInclude Include="Rewrite.h" />
+    <ClInclude Include="RewriteDstId.h" />
     <ClInclude Include="RewritePC.h" />
     <ClInclude Include="RewriteSrc.h" />
+    <ClInclude Include="RewriteSrcId.h" />
     <ClInclude Include="RewriteTG.h" />
     <ClInclude Include="RewriteType.h" />
     <ClInclude Include="RingBuffer.h" />
@@ -216,8 +218,10 @@
     <ClCompile Include="Reflectors.cpp" />
     <ClCompile Include="RepeaterProtocol.cpp" />
     <ClCompile Include="Rewrite.cpp" />
+    <ClCompile Include="RewriteDstId.cpp" />
     <ClCompile Include="RewritePC.cpp" />
     <ClCompile Include="RewriteSrc.cpp" />
+    <ClCompile Include="RewriteSrcId.cpp" />
     <ClCompile Include="RewriteTG.cpp" />
     <ClCompile Include="RewriteType.cpp" />
     <ClCompile Include="RS129.cpp" />

--- a/DMRGateway.vcxproj.filters
+++ b/DMRGateway.vcxproj.filters
@@ -107,7 +107,13 @@
     <ClInclude Include="Rewrite.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="RewriteDstId.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="RewriteSrc.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="RewriteSrcId.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="RewriteType.h">
@@ -217,7 +223,13 @@
     <ClCompile Include="Rewrite.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="RewriteDstId.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="RewriteSrc.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="RewriteSrcId.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="RewriteType.cpp">

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ LIBS    = -lpthread
 LDFLAGS = -g
 
 OBJECTS = BPTC19696.o Conf.o CRC.o DMRCSBK.o DMRData.o DMRDataHeader.o DMREmbeddedData.o DMREMB.o DMRFullLC.o DMRGateway.o DMRLC.o DMRNetwork.o DMRSlotType.o \
-					Golay2087.o Hamming.o Log.o MMDVMNetwork.o PassAllPC.o PassAllTG.o QR1676.o Reflectors.o RepeaterProtocol.o Rewrite.o RewritePC.o RewriteSrc.o RewriteTG.o \
-					RewriteType.o RS129.o SHA256.o StopWatch.o Sync.o Thread.o Timer.o UDPSocket.o Utils.o Voice.o
+					Golay2087.o Hamming.o Log.o MMDVMNetwork.o PassAllPC.o PassAllTG.o QR1676.o Reflectors.o RepeaterProtocol.o Rewrite.o RewriteDstId.o RewritePC.o RewriteSrc.o \
+					RewriteSrcId.o RewriteTG.o RewriteType.o RS129.o SHA256.o StopWatch.o Sync.o Thread.o Timer.o UDPSocket.o Utils.o Voice.o
 
 all:	DMRGateway
 

--- a/RewriteDstId.cpp
+++ b/RewriteDstId.cpp
@@ -1,0 +1,60 @@
+/*
+*   Copyright (C) 2017 by Jonathan Naylor G4KLX
+*
+*   This program is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation; either version 2 of the License, or
+*   (at your option) any later version.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program; if not, write to the Free Software
+*   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+*/
+
+#include "RewriteDstId.h"
+
+#include "DMRDefines.h"
+#include "Log.h"
+
+#include <cstdio>
+
+CRewriteDstId::CRewriteDstId(const std::string& name, unsigned int fromId, unsigned int toId) :
+CRewrite(),
+m_name(name),
+m_fromId(fromId),
+m_toId(toId)
+{
+}
+
+CRewriteDstId::~CRewriteDstId()
+{
+}
+
+bool CRewriteDstId::process(CDMRData& data, bool trace)
+{
+	FLCO flco = data.getFLCO();
+	unsigned int dstId = data.getDstId();
+
+	if (flco != FLCO_USER_USER || dstId != m_fromId) {
+		if (trace)
+			LogDebug("Rule Trace,\tRewriteDstId from %s Src=%u: not matched", m_name.c_str(), m_fromId);
+
+		return false;
+	}
+
+	data.setDstId(m_toId);
+
+	processMessage(data);
+
+	if (trace) {
+		LogDebug("Rule Trace,\tRewriteDstId from %s Src=%u: matched", m_name.c_str(), m_fromId);
+		LogDebug("Rule Trace,\tRewriteDstId to %s Src=%u", m_name.c_str(), m_toId);
+	}
+
+	return true;
+}

--- a/RewriteDstId.h
+++ b/RewriteDstId.h
@@ -1,0 +1,41 @@
+/*
+*   Copyright (C) 2017 by Jonathan Naylor G4KLX
+*
+*   This program is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation; either version 2 of the License, or
+*   (at your option) any later version.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program; if not, write to the Free Software
+*   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+*/
+
+#if !defined(REWRITEDSTID_H)
+#define	REWRITEDSTID_H
+
+#include "Rewrite.h"
+#include "DMRData.h"
+
+#include <string>
+
+class CRewriteDstId : public CRewrite {
+public:
+	CRewriteDstId(const std::string& name, unsigned int fromId, unsigned int toID);
+	virtual ~CRewriteDstId();
+
+	virtual bool process(CDMRData& data, bool trace);
+
+private:
+	std::string  m_name;
+	unsigned int m_fromId;
+	unsigned int m_toId;
+};
+
+
+#endif

--- a/RewriteSrcId.cpp
+++ b/RewriteSrcId.cpp
@@ -1,0 +1,59 @@
+/*
+*   Copyright (C) 2017 by Jonathan Naylor G4KLX
+*
+*   This program is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation; either version 2 of the License, or
+*   (at your option) any later version.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program; if not, write to the Free Software
+*   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+*/
+
+#include "RewriteSrcId.h"
+
+#include "DMRDefines.h"
+#include "Log.h"
+
+#include <cstdio>
+
+CRewriteSrcId::CRewriteSrcId(const std::string& name, unsigned int fromId, unsigned int toId) :
+CRewrite(),
+m_name(name),
+m_fromId(fromId),
+m_toId(toId)
+{
+}
+
+CRewriteSrcId::~CRewriteSrcId()
+{
+}
+
+bool CRewriteSrcId::process(CDMRData& data, bool trace)
+{
+	unsigned int srcId = data.getSrcId();
+
+	if (srcId != m_fromId) {
+		if (trace)
+			LogDebug("Rule Trace,\tRewriteSrcId from %s Src=%u: not matched", m_name.c_str(), m_fromId);
+
+		return false;
+	}
+
+	data.setSrcId(m_toId);
+
+	processMessage(data);
+
+	if (trace) {
+		LogDebug("Rule Trace,\tRewriteSrcId from %s Src=%u: matched", m_name.c_str(), m_fromId);
+		LogDebug("Rule Trace,\tRewriteSrcId to %s Src=%u", m_name.c_str(), m_toId);
+	}
+
+	return true;
+}

--- a/RewriteSrcId.h
+++ b/RewriteSrcId.h
@@ -1,0 +1,41 @@
+/*
+*   Copyright (C) 2017 by Jonathan Naylor G4KLX
+*
+*   This program is free software; you can redistribute it and/or modify
+*   it under the terms of the GNU General Public License as published by
+*   the Free Software Foundation; either version 2 of the License, or
+*   (at your option) any later version.
+*
+*   This program is distributed in the hope that it will be useful,
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*   GNU General Public License for more details.
+*
+*   You should have received a copy of the GNU General Public License
+*   along with this program; if not, write to the Free Software
+*   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+*/
+
+#if !defined(REWRITESRCID_H)
+#define	REWRITESRCID_H
+
+#include "Rewrite.h"
+#include "DMRData.h"
+
+#include <string>
+
+class CRewriteSrcId : public CRewrite {
+public:
+	CRewriteSrcId(const std::string& name, unsigned int fromId, unsigned int toID);
+	virtual ~CRewriteSrcId();
+
+	virtual bool process(CDMRData& data, bool trace);
+
+private:
+	std::string  m_name;
+	unsigned int m_fromId;
+	unsigned int m_toId;
+};
+
+
+#endif


### PR DESCRIPTION
Solved #57 by adding the *IdRewrite=RFId,NetId* rule to the network configuration section. Multiple such rules can be specified for one network. Matching source Id is rewritten before writing to the network, incoming private calls to the Network Id are rewritten to the RF Id.