### PR TITLE
TypeRewrite with optional range

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -381,13 +381,15 @@ bool CConf::read()
 				char* p1 = ::strtok(value, ", ");
 				char* p2 = ::strtok(NULL, ", ");
 				char* p3 = ::strtok(NULL, ", ");
-				char* p4 = ::strtok(NULL, " \r\n");
+				char* p4 = ::strtok(NULL, ", \r\n");
 				if (p1 != NULL && p2 != NULL && p3 != NULL && p4 != NULL) {
 					CTypeRewriteStruct rewrite;
 					rewrite.m_fromSlot = ::atoi(p1);
 					rewrite.m_fromTG   = ::atoi(p2);
 					rewrite.m_toSlot   = ::atoi(p3);
 					rewrite.m_toId     = ::atoi(p4);
+					char* p5 = ::strtok(NULL, " \r\n");
+					rewrite.m_range    = p5 != NULL ? ::atoi(p5) : 1;
 					m_dmrNetwork1TypeRewrites.push_back(rewrite);
 				}
 			} else if (::strncmp(key, "SrcRewrite", 10U) == 0) {
@@ -493,13 +495,15 @@ bool CConf::read()
 				char* p1 = ::strtok(value, ", ");
 				char* p2 = ::strtok(NULL, ", ");
 				char* p3 = ::strtok(NULL, ", ");
-				char* p4 = ::strtok(NULL, " \r\n");
+				char* p4 = ::strtok(NULL, ", \r\n");
 				if (p1 != NULL && p2 != NULL && p3 != NULL && p4 != NULL) {
 					CTypeRewriteStruct rewrite;
 					rewrite.m_fromSlot = ::atoi(p1);
 					rewrite.m_fromTG   = ::atoi(p2);
 					rewrite.m_toSlot   = ::atoi(p3);
 					rewrite.m_toId     = ::atoi(p4);
+					char* p5 = ::strtok(NULL, " \r\n");
+					rewrite.m_range    = p5 != NULL ? ::atoi(p5) : 1;
 					m_dmrNetwork2TypeRewrites.push_back(rewrite);
 				}
 			} else if (::strncmp(key, "SrcRewrite", 10U) == 0) {
@@ -605,13 +609,15 @@ bool CConf::read()
 				char* p1 = ::strtok(value, ", ");
 				char* p2 = ::strtok(NULL, ", ");
 				char* p3 = ::strtok(NULL, ", ");
-				char* p4 = ::strtok(NULL, " \r\n");
+				char* p4 = ::strtok(NULL, ", \r\n");
 				if (p1 != NULL && p2 != NULL && p3 != NULL && p4 != NULL) {
 					CTypeRewriteStruct rewrite;
 					rewrite.m_fromSlot = ::atoi(p1);
 					rewrite.m_fromTG   = ::atoi(p2);
 					rewrite.m_toSlot   = ::atoi(p3);
 					rewrite.m_toId     = ::atoi(p4);
+					char* p5 = ::strtok(NULL, " \r\n");
+					rewrite.m_range    = p5 != NULL ? ::atoi(p5) : 1;
 					m_dmrNetwork3TypeRewrites.push_back(rewrite);
 				}
 			} else if (::strncmp(key, "SrcRewrite", 10U) == 0) {
@@ -717,13 +723,15 @@ bool CConf::read()
 				char* p1 = ::strtok(value, ", ");
 				char* p2 = ::strtok(NULL, ", ");
 				char* p3 = ::strtok(NULL, ", ");
-				char* p4 = ::strtok(NULL, " \r\n");
+				char* p4 = ::strtok(NULL, ", \r\n");
 				if (p1 != NULL && p2 != NULL && p3 != NULL && p4 != NULL) {
 					CTypeRewriteStruct rewrite;
 					rewrite.m_fromSlot = ::atoi(p1);
 					rewrite.m_fromTG   = ::atoi(p2);
 					rewrite.m_toSlot   = ::atoi(p3);
 					rewrite.m_toId     = ::atoi(p4);
+					char* p5 = ::strtok(NULL, " \r\n");
+					rewrite.m_range    = p5 != NULL ? ::atoi(p5) : 1;
 					m_dmrNetwork4TypeRewrites.push_back(rewrite);
 				}
 			} else if (::strncmp(key, "SrcRewrite", 10U) == 0) {
@@ -829,13 +837,15 @@ bool CConf::read()
 				char* p1 = ::strtok(value, ", ");
 				char* p2 = ::strtok(NULL, ", ");
 				char* p3 = ::strtok(NULL, ", ");
-				char* p4 = ::strtok(NULL, " \r\n");
+				char* p4 = ::strtok(NULL, ", \r\n");
 				if (p1 != NULL && p2 != NULL && p3 != NULL && p4 != NULL) {
 					CTypeRewriteStruct rewrite;
 					rewrite.m_fromSlot = ::atoi(p1);
 					rewrite.m_fromTG   = ::atoi(p2);
 					rewrite.m_toSlot   = ::atoi(p3);
 					rewrite.m_toId     = ::atoi(p4);
+					char* p5 = ::strtok(NULL, " \r\n");
+					rewrite.m_range    = p5 != NULL ? ::atoi(p5) : 1;
 					m_dmrNetwork5TypeRewrites.push_back(rewrite);
 				}
 			} else if (::strncmp(key, "SrcRewrite", 10U) == 0) {

--- a/Conf.h
+++ b/Conf.h
@@ -43,6 +43,7 @@ struct CTypeRewriteStruct {
 	unsigned int m_fromTG;
 	unsigned int m_toSlot;
 	unsigned int m_toId;
+	unsigned int m_range;
 };
 
 struct CSrcRewriteStruct {

--- a/DMRGateway.cpp
+++ b/DMRGateway.cpp
@@ -1337,9 +1337,12 @@ bool CDMRGateway::createDMRNetwork1(CDynVoice* voice)
 
 	std::vector<CTypeRewriteStruct> typeRewrites = m_conf.getDMRNetwork1TypeRewrites();
 	for (std::vector<CTypeRewriteStruct>::const_iterator it = typeRewrites.begin(); it != typeRewrites.end(); ++it) {
-		LogInfo("    Rewrite RF: %u:TG%u -> %u:%u", (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId);
+		if ((*it).m_range == 1)
+			LogInfo("    Rewrite RF: %u:TG%u -> %u:%u", (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId);
+		else
+			LogInfo("    Rewrite RF: %u:TG%u-%u -> %u:%u-%u", (*it).m_fromSlot, (*it).m_fromTG, (*it).m_fromTG + (*it).m_range - 1U, (*it).m_toSlot, (*it).m_toId, (*it).m_toId + (*it).m_range - 1U);
 
-		CRewriteType* rewrite = new CRewriteType(m_dmr1Name, (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId);
+		CRewriteType* rewrite = new CRewriteType(m_dmr1Name, (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId, (*it).m_range);
 
 		m_dmr1RFRewrites.push_back(rewrite);
 	}
@@ -1486,9 +1489,12 @@ bool CDMRGateway::createDMRNetwork2(CDynVoice* voice)
 
 	std::vector<CTypeRewriteStruct> typeRewrites = m_conf.getDMRNetwork2TypeRewrites();
 	for (std::vector<CTypeRewriteStruct>::const_iterator it = typeRewrites.begin(); it != typeRewrites.end(); ++it) {
-		LogInfo("    Rewrite RF: %u:TG%u -> %u:%u", (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId);
+		if ((*it).m_range == 1)
+			LogInfo("    Rewrite RF: %u:TG%u -> %u:%u", (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId);
+		else
+			LogInfo("    Rewrite RF: %u:TG%u-%u -> %u:%u-%u", (*it).m_fromSlot, (*it).m_fromTG, (*it).m_fromTG + (*it).m_range - 1U, (*it).m_toSlot, (*it).m_toId, (*it).m_toId + (*it).m_range - 1U);
 
-		CRewriteType* rewrite = new CRewriteType(m_dmr2Name, (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId);
+		CRewriteType* rewrite = new CRewriteType(m_dmr2Name, (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId, (*it).m_range);
 
 		m_dmr2RFRewrites.push_back(rewrite);
 	}
@@ -1635,9 +1641,12 @@ bool CDMRGateway::createDMRNetwork3(CDynVoice* voice)
 
 	std::vector<CTypeRewriteStruct> typeRewrites = m_conf.getDMRNetwork3TypeRewrites();
 	for (std::vector<CTypeRewriteStruct>::const_iterator it = typeRewrites.begin(); it != typeRewrites.end(); ++it) {
-		LogInfo("    Rewrite RF: %u:TG%u -> %u:%u", (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId);
+		if ((*it).m_range == 1)
+			LogInfo("    Rewrite RF: %u:TG%u -> %u:%u", (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId);
+		else
+			LogInfo("    Rewrite RF: %u:TG%u-%u -> %u:%u-%u", (*it).m_fromSlot, (*it).m_fromTG, (*it).m_fromTG + (*it).m_range - 1U, (*it).m_toSlot, (*it).m_toId, (*it).m_toId + (*it).m_range - 1U);
 
-		CRewriteType* rewrite = new CRewriteType(m_dmr3Name, (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId);
+		CRewriteType* rewrite = new CRewriteType(m_dmr3Name, (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId, (*it).m_range);
 
 		m_dmr3RFRewrites.push_back(rewrite);
 	}
@@ -1784,9 +1793,12 @@ bool CDMRGateway::createDMRNetwork4(CDynVoice* voice)
 
 	std::vector<CTypeRewriteStruct> typeRewrites = m_conf.getDMRNetwork4TypeRewrites();
 	for (std::vector<CTypeRewriteStruct>::const_iterator it = typeRewrites.begin(); it != typeRewrites.end(); ++it) {
-		LogInfo("    Rewrite RF: %u:TG%u -> %u:%u", (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId);
+		if ((*it).m_range == 1)
+			LogInfo("    Rewrite RF: %u:TG%u -> %u:%u", (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId);
+		else
+			LogInfo("    Rewrite RF: %u:TG%u-%u -> %u:%u-%u", (*it).m_fromSlot, (*it).m_fromTG, (*it).m_fromTG + (*it).m_range - 1U, (*it).m_toSlot, (*it).m_toId, (*it).m_toId + (*it).m_range - 1U);
 
-		CRewriteType* rewrite = new CRewriteType(m_dmr4Name, (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId);
+		CRewriteType* rewrite = new CRewriteType(m_dmr4Name, (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId, (*it).m_range);
 
 		m_dmr4RFRewrites.push_back(rewrite);
 	}
@@ -1933,9 +1945,12 @@ bool CDMRGateway::createDMRNetwork5(CDynVoice* voice)
 
 	std::vector<CTypeRewriteStruct> typeRewrites = m_conf.getDMRNetwork5TypeRewrites();
 	for (std::vector<CTypeRewriteStruct>::const_iterator it = typeRewrites.begin(); it != typeRewrites.end(); ++it) {
-		LogInfo("    Rewrite RF: %u:TG%u -> %u:%u", (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId);
+		if ((*it).m_range == 1)
+			LogInfo("    Rewrite RF: %u:TG%u -> %u:%u", (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId);
+		else
+			LogInfo("    Rewrite RF: %u:TG%u-%u -> %u:%u-%u", (*it).m_fromSlot, (*it).m_fromTG, (*it).m_fromTG + (*it).m_range - 1U, (*it).m_toSlot, (*it).m_toId, (*it).m_toId + (*it).m_range - 1U);
 
-		CRewriteType* rewrite = new CRewriteType(m_dmr5Name, (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId);
+		CRewriteType* rewrite = new CRewriteType(m_dmr5Name, (*it).m_fromSlot, (*it).m_fromTG, (*it).m_toSlot, (*it).m_toId, (*it).m_range);
 
 		m_dmr5RFRewrites.push_back(rewrite);
 	}

--- a/RewriteType.cpp
+++ b/RewriteType.cpp
@@ -24,13 +24,15 @@
 #include <cstdio>
 #include <cassert>
 
-CRewriteType::CRewriteType(const std::string& name, unsigned int fromSlot, unsigned int fromTG, unsigned int toSlot, unsigned int toId) :
+CRewriteType::CRewriteType(const std::string& name, unsigned int fromSlot, unsigned int fromTG, unsigned int toSlot, unsigned int toId, unsigned int range) :
 CRewrite(),
 m_name(name),
 m_fromSlot(fromSlot),
-m_fromTG(fromTG),
+m_fromTGStart(fromTG),
+m_fromTGEnd(fromTG + range - 1U),
 m_toSlot(toSlot),
-m_toId(toId)
+m_toIdStart(toId),
+m_toIdEnd(toId + range - 1U)
 {
 	assert(fromSlot == 1U || fromSlot == 2U);
 	assert(toSlot == 1U || toSlot == 2U);
@@ -46,23 +48,37 @@ PROCESS_RESULT CRewriteType::process(CDMRData& data, bool trace)
 	unsigned int dstId  = data.getDstId();
 	unsigned int slotNo = data.getSlotNo();
 
-	if (flco != FLCO_GROUP || slotNo != m_fromSlot || dstId != m_fromTG) {
-		if (trace)
-			LogDebug("Rule Trace,\tRewriteType %s Slot=%u Dst=TG%u: not matched", m_name.c_str(), m_fromSlot, m_fromTG);
-
+	if (flco != FLCO_GROUP || slotNo != m_fromSlot || dstId < m_fromTGStart || dstId > m_fromTGEnd) {
+		if (trace) {
+			if (m_fromTGStart == m_fromTGEnd)
+				LogDebug("Rule Trace,\tRewriteType from \"%s\" Slot=%u Dst=TG%u: not matched", m_name.c_str(), m_fromSlot, m_fromTGStart);
+			else
+				LogDebug("Rule Trace,\tRewriteType from \"%s\" Slot=%u Dst=TG%u-%u: not matched", m_name.c_str(), m_fromSlot, m_fromTGStart, m_fromTGEnd);
+		}
 		return RESULT_UNMATCHED;
 	}
 
 	if (m_fromSlot != m_toSlot)
 		data.setSlotNo(m_toSlot);
 
-	data.setDstId(m_toId);
+	if (m_fromTGStart != m_toIdStart) {
+		unsigned int newDstId = dstId + m_toIdStart - m_fromTGStart;
+		data.setDstId(newDstId);
+	}
 	data.setFLCO(FLCO_USER_USER);
 
 	processMessage(data);
 
-	if (trace)
-		LogDebug("Rule Trace,\tRewriteType %s Slot=%u Dst=TG%u: matched", m_name.c_str(), m_fromSlot, m_fromTG);
+	if (trace) {
+		if (m_fromTGStart == m_fromTGEnd)
+			LogDebug("Rule Trace,\tRewriteType from \"%s\" Slot=%u Dst=TG%u: not matched", m_name.c_str(), m_fromSlot, m_fromTGStart);
+		else
+			LogDebug("Rule Trace,\tRewriteType from \"%s\" Slot=%u Dst=TG%u-%u: not matched", m_name.c_str(), m_fromSlot, m_fromTGStart, m_fromTGEnd);
+		if (m_toIdStart == m_toIdEnd)
+			LogDebug("Rule Trace,\tRewriteType  to  \"\%s\" Slot=%u Dst=%u: matched", m_name.c_str(), m_toSlot, m_toIdStart);
+		else
+			LogDebug("Rule Trace,\tRewriteType  to  \"\%s\" Slot=%u Dst=%u-%u: matched", m_name.c_str(), m_toSlot, m_toIdStart, m_toIdEnd);
+	}
 
 	return RESULT_MATCHED;
 }

--- a/RewriteType.h
+++ b/RewriteType.h
@@ -26,7 +26,7 @@
 
 class CRewriteType : public CRewrite {
 public:
-	CRewriteType(const std::string& name, unsigned int fromSlot, unsigned int fromTG, unsigned int toSlot, unsigned int toId);
+	CRewriteType(const std::string& name, unsigned int fromSlot, unsigned int fromTG, unsigned int toSlot, unsigned int toId, unsigned int range);
 	virtual ~CRewriteType();
 
 	virtual PROCESS_RESULT process(CDMRData& data, bool trace);
@@ -34,9 +34,11 @@ public:
 private:
 	std::string  m_name;
 	unsigned int m_fromSlot;
-	unsigned int m_fromTG;
+	unsigned int m_fromTGStart;
+	unsigned int m_fromTGEnd;
 	unsigned int m_toSlot;
-	unsigned int m_toId;
+	unsigned int m_toIdStart;
+	unsigned int m_toIdEnd;
 };
 
 


### PR DESCRIPTION
`TypeRewrite` with additional range option support.
Full range(4000~5000) reflector control with single line.

```
#XLX[NET0]=102xxxxx, BM[NET1]=11Txxxxx, NET2=12[12]xxxxx, ..., NET5=15[12]xxxxx
[DMR Network 4]
TypeRewrite_RF400=2,14004000,2,4000,1001
TypeRewrite_RF400=1,14004000,2,4000,1001
[DMR Network 5]
TypeRewrite_RF501=2,15004000,2,4000,1001
TypeRewrite_RF501=1,15004000,2,4000,1001
```
RF:TS*:TG:14004800 -->MMDVM--> NET4:TS2:PC4800 [Connect 4800 reflector]
RF:TS*:TG:15004000 -->MMDVM--> NET5:TS2:PC5000 [Poll connected Reflector in voice]



