### PR TITLE
Update DMRGateway.ini

### DIFF
--- a/DMRGateway.ini
+++ b/DMRGateway.ini
@@ -99,20 +99,8 @@ Password=PASSWORD
 Location=0
 Debug=0
 
-# TGIF Network
-[DMR Network 3]
-Enabled=0
-Name=TGIF_Network
-TGRewrite0=1,1,2,1,9999998
-SrcRewrite0=2,1,1,1,9999998
-Address=tgif.network
-Password=passw0rd
-Port=62031
-Location=0
-Debug=0
-
 # Local HBLink 1 network
-[DMR Network 4]
+[DMR Network 3]
 Enabled=0
 Name=HBLink 1
 Address=44.131.4.2
@@ -121,6 +109,18 @@ Port=55555
 # Local area TG on to slot 2 TG11
 TGRewrite=2,11,2,11,1
 Password=PASSWORD
+Location=0
+Debug=0
+
+# TGIF Network
+[DMR Network 4]
+Enabled=0
+Name=TGIF_Network
+TGRewrite0=1,1,2,1,9999998
+SrcRewrite0=2,1,1,1,9999998
+Address=tgif.network
+Password=passw0rd
+Port=62031
 Location=0
 Debug=0
 


### PR DESCRIPTION
Swapped Network 3 and 4. 
Network 3 is used for dmr2??? crossovers and defaults to HBLink
Pi-Star configurator overwrites Network 3