### PR TITLE
Update DMRGateway.ini

### DIFF
--- a/DMRGateway.ini
+++ b/DMRGateway.ini
@@ -69,6 +69,10 @@ SrcRewrite=1,9990,1,9990,1
 SrcRewrite=2,4000,2,9,1001
 # Dynamic rewriting of slot 2 TGs 90-999999 to TG9 to emulate reflector behaviour
 TGDynRewrite=2,90,4000,5000,9,999910,9990
+# For normal repeater operation disable TGDyn coment out the above line
+# After that remove the coments below
+# PassAllTG=1
+# PassAllTG=2
 # Pass all of the other private traffic on slot 1 and slot 2
 PassAllPC=1
 PassAllPC=2


### PR DESCRIPTION
For normal repeater operation using some rigs dynamic rewrite is not usefull, not all have Promiscous mode. Reflectors are disabled (allmost) on Brandmeister Network.