### PR TITLE
Allow option for APRS Symbols to be defined/configured.

### DIFF
--- a/APRSWriter.cpp
+++ b/APRSWriter.cpp
@@ -35,6 +35,7 @@ m_latitude(0.0F),
 m_longitude(0.0F),
 m_height(0),
 m_desc(),
+m_symbol(),
 m_aprsAddr(),
 m_aprsLen(0U),
 m_aprsSocket()
@@ -56,11 +57,13 @@ CAPRSWriter::~CAPRSWriter()
 {
 }
 
-void CAPRSWriter::setInfo(unsigned int txFrequency, unsigned int rxFrequency, const std::string& desc)
+void CAPRSWriter::setInfo(unsigned int txFrequency, unsigned int rxFrequency, const std::string& desc, const std::string& symbol)
+
 {
 	m_txFrequency = txFrequency;
 	m_rxFrequency = rxFrequency;
 	m_desc        = desc;
+	m_symbol      = symbol;
 }
 
 void CAPRSWriter::setLocation(float latitude, float longitude, int height)
@@ -149,17 +152,21 @@ void CAPRSWriter::sendIdFrame()
 	::sprintf(lon, "%08.2lf", longitude);
 
 	std::string server = m_callsign;
+	std::string symbol = m_symbol;
 	size_t pos = server.find_first_of('-');
 	if (pos == std::string::npos)
 		server.append("-S");
 	else
 		server.append("S");
 
+        if (symbol.empty())
+                symbol.append("D&");
+
 	char output[500U];
-	::sprintf(output, "%s>APDG03,TCPIP*,qAC,%s:!%s%cD%s%c&/A=%06.0f%s %s\r\n",
+	::sprintf(output, "%s>APDG03,TCPIP*,qAC,%s:!%s%c%c%s%c%c/A=%06.0f%s %s\r\n",
 		m_callsign.c_str(), server.c_str(),
-		lat, (m_latitude < 0.0F)  ? 'S' : 'N',
-		lon, (m_longitude < 0.0F) ? 'W' : 'E',
+		lat, (m_latitude < 0.0F)  ? 'S' : 'N', symbol[0],
+		lon, (m_longitude < 0.0F) ? 'W' : 'E', symbol[1],
 		float(m_height) * 3.28F, band, desc);
 
 	if (m_debug)

--- a/APRSWriter.h
+++ b/APRSWriter.h
@@ -44,7 +44,7 @@ public:
 
 	bool open();
 
-	void setInfo(unsigned int txFrequency, unsigned int rxFrequency, const std::string& desc);
+	void setInfo(unsigned int txFrequency, unsigned int rxFrequency, const std::string& desc, const std::string& symbol);
 
 	void setLocation(float latitude, float longitude, int height);
 
@@ -62,6 +62,7 @@ private:
 	float             m_longitude;
 	int               m_height;
 	std::string       m_desc;
+	std::string       m_symbol;
 	sockaddr_storage  m_aprsAddr;
 	unsigned int      m_aprsLen;
 	CUDPSocket        m_aprsSocket;

--- a/Conf.cpp
+++ b/Conf.cpp
@@ -182,6 +182,7 @@ m_aprsAddress(),
 m_aprsPort(0U),
 m_aprsSuffix(),
 m_aprsDescription(),
+m_aprsSymbol(),
 m_dynamicTGControlEnabled(false),
 m_dynamicTGControlPort(3769U),
 m_remoteControlEnabled(false),
@@ -989,6 +990,8 @@ bool CConf::read()
 				m_aprsSuffix = value;
 			else if (::strcmp(key, "Description") == 0)
 				m_aprsDescription = value;
+                        else if (::strcmp(key, "Symbol") == 0)
+                                m_aprsSymbol = value;
 		} else if (section == SECTION_DYNAMIC_TG_CONTROL) {
 			if (::strcmp(key, "Enabled") == 0)
 				m_dynamicTGControlEnabled = ::atoi(value) == 1;
@@ -1700,6 +1703,11 @@ std::string CConf::getAPRSSuffix() const
 std::string CConf::getAPRSDescription() const
 {
 	return m_aprsDescription;
+}
+
+std::string CConf::getAPRSSymbol() const
+{
+       return m_aprsSymbol;
 }
 
 bool CConf::getDynamicTGControlEnabled() const

--- a/Conf.h
+++ b/Conf.h
@@ -236,6 +236,7 @@ public:
 	unsigned short getAPRSPort() const;
 	std::string  getAPRSSuffix() const;
 	std::string  getAPRSDescription() const;
+	std::string  getAPRSSymbol() const;
 
 	// The Dynamic TG Control section
 	bool         getDynamicTGControlEnabled() const;
@@ -395,6 +396,7 @@ private:
 	unsigned short m_aprsPort;
 	std::string  m_aprsSuffix;
 	std::string  m_aprsDescription;
+	std::string  m_aprsSymbol;
 
 	bool         m_dynamicTGControlEnabled;
 	unsigned short m_dynamicTGControlPort;

--- a/DMRGateway.cpp
+++ b/DMRGateway.cpp
@@ -2528,8 +2528,9 @@ void CDMRGateway::createAPRS()
 	m_writer = new CAPRSWriter(m_callsign, suffix, address, port, debug);
 
 	std::string desc    = m_conf.getAPRSDescription();
+	std::string symbol  = m_conf.getAPRSSymbol();
 
-	m_writer->setInfo(m_txFrequency, m_rxFrequency, desc);
+	m_writer->setInfo(m_txFrequency, m_rxFrequency, desc, symbol);
 
 	float latitude  = m_conf.getInfoLatitude();
 	float longitude = m_conf.getInfoLongitude();

--- a/DMRGateway.ini
+++ b/DMRGateway.ini
@@ -149,6 +149,7 @@ Address=127.0.0.1
 Port=8673
 Description=APRS Description
 Suffix=3
+# Symbol=/r
 
 [Dynamic TG Control]
 Enabled=1

--- a/Version.h
+++ b/Version.h
@@ -19,6 +19,6 @@
 #if !defined(VERSION_H)
 #define	VERSION_H
 
-const char* VERSION = "20210409";
+const char* VERSION = "20230212";
 
 #endif


### PR DESCRIPTION
This PR adds a  `Symbol=` option to `[APRS]` stanza in config, to allow user to define APRS symbol.
Backwards-compatible, and will default to the standard DMRGateway `D&` symbol (diamond with "D" overlay) if `Symbol=` is not defined.

Supports primary and alternate/secondary symbol selections, plus overlays[^1].

Examples:
```ini
[APRS]
Symbol=/r (repeater tower)
Symbol=Wi (black square [alternate] with "W" overlay)
Symbol=\> (alternate car icon)
Symbol=/l (computer)
```
_(Note that only one `Symbol=` should be defined in the `[APRS]` config section/stanza.)_

[^1]: Nice chart with symbols, primary/alternate & overlay selectors: https://blog.thelifeofkenneth.com/2017/01/aprs-symbol-look-up-table.html