### PR TITLE
Configuration parsing bugfix

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -262,8 +262,8 @@ bool CConf::read()
 		char *p;
 
 		// if value is not quoted, remove after # (to make comment)
-		if ((p = strchr(value, '#')) != NULL)
-			*p = '\0';
+		if ((p = strchr(value, '#')) != NULL && p == value)
+		    *p = '\0';
 
 		// remove trailing tab/space
 		for (p = value + strlen(value) - 1U; p >= value && (*p == '\t' || *p == ' '); p--)


### PR DESCRIPTION
Fixes configuration bug; when "Symbol=" value contains a valid APRS literal "#", it was parsed as a comment and not honored (now has more strict checking).