### PR TITLE
Embedded data was not being passed through during rewrite

### DIFF
--- a/Rewrite.cpp
+++ b/Rewrite.cpp
@@ -110,17 +110,7 @@ void CRewrite::processEmbeddedData(unsigned char* data, unsigned char n)
 		return;
 	}
 
-	CDMRLC* lc = m_data[m_readNum].getLC();
-	if (lc == NULL) {
-		lcss = m_embeddedLC.getData(data, n);
-		emb.setLCSS(lcss);
-		emb.getData(data);
-		return;
-	}
-
-	FLCO flco = lc->getFLCO();
-
-	delete lc;
+	FLCO flco = m_data[m_readNum].getFLCO();
 
 	// Replace any identity embedded data with the new one
 	if (flco == FLCO_GROUP || flco == FLCO_USER_USER)


### PR DESCRIPTION
I've tested that this change allows DMR enbedded data like talker alias and GPS to be passed through during talkgroup rewrite.