### PR TITLE
Fix SIGHUP treatment to loop/restart as intended

### DIFF
--- a/DMRGateway.cpp
+++ b/DMRGateway.cpp
@@ -101,6 +101,7 @@ int main(int argc, char** argv)
 
 	do {
 		m_signal = 0;
+		m_killed = false;	// restart, don't exit, if looping from SIGHUP (1)
 
 		CDMRGateway* host = new CDMRGateway(std::string(iniFile));
 		ret = host->run();


### PR DESCRIPTION
There's a do...while(m_signal==1) intended to allow a SIGHUP (1) to cause a restart, rather than an exit.  But the current code doesn't reset m_killed, so it does instantiate a new DMRGateway object, but then exits.