### PR TITLE
Fix crash on empty MQTT command message

### DIFF
--- a/RemoteControl.cpp
+++ b/RemoteControl.cpp
@@ -62,6 +62,12 @@ REMOTE_COMMAND CRemoteControl::processCommand(const std::string& command)
 		start = command.find_first_not_of(' ', end);
 	}
 
+	if (m_args.empty()) {
+		if (m_mqtt != nullptr)
+			m_mqtt->publish("response", "KO");
+		return REMOTE_COMMAND::NONE;
+	}
+
 	if (m_args.at(0U) == "enable" && m_args.size() >= ENABLE_ARGS) {
 		if (m_args.at(1U) == "net1")
 			m_command = REMOTE_COMMAND::ENABLE_NETWORK1;
@@ -122,7 +128,8 @@ REMOTE_COMMAND CRemoteControl::processCommand(const std::string& command)
 #endif
 	}
 
-	m_mqtt->publish("response", replyStr);
+	if (m_mqtt != nullptr)
+		m_mqtt->publish("response", replyStr);
 	
 	return m_command;
 }


### PR DESCRIPTION
## Summary
- Empty or whitespace-only MQTT command messages caused an unhandled `std::out_of_range` exception
- The exception on the mosquitto callback thread killed the entire gateway process
- Add early return when no command tokens are parsed
- Add null check on `m_mqtt` before publishing response

## Test plan
- Publish an empty message to the command topic — verify gateway stays running and responds "KO"
- Publish a valid command — verify it still works