### PR TITLE
Fix stale slot number after RF rewrite

### DIFF
--- a/DMRGateway.cpp
+++ b/DMRGateway.cpp
@@ -620,6 +620,7 @@ int CDMRGateway::run()
 						}
 
 						if (result == PROCESS_RESULT::MATCHED) {
+							slotNo = data.getSlotNo();
 							if (m_extStatus[slotNo].m_status == DMRGW_STATUS::NONE || (
 									m_extStatus[slotNo].m_status == DMRGW_STATUS::DMRNETWORK &&
 									m_extStatus[slotNo].m_dmrNetwork == i)
@@ -650,6 +651,7 @@ int CDMRGateway::run()
 						}
 
 						if (result == PROCESS_RESULT::MATCHED) {
+							slotNo = data.getSlotNo();
 							if (m_extStatus[slotNo].m_status == DMRGW_STATUS::NONE || (
 									m_extStatus[slotNo].m_status == DMRGW_STATUS::DMRNETWORK &&
 									m_extStatus[slotNo].m_dmrNetwork == i)


### PR DESCRIPTION
## Summary
- RF→network path captured slotNo before rewrite rules ran, then used it for status/timers
- Cross-slot rewrites (slot 1→2 or 2→1) would track the wrong slot
- Re-read data.getSlotNo() after rewrite, matching the network→RF path pattern

## Test plan
- Configure a cross-slot TG rewrite (e.g., slot 1 TG9 → slot 2 TG9)
- Transmit on slot 1 — verify status tracks slot 2 correctly
- Verify timeout fires on the correct slot