### PR TITLE
Fix memory leak of config data in CDMRNetwork

### DIFF
--- a/DMRNetwork.cpp
+++ b/DMRNetwork.cpp
@@ -78,6 +78,7 @@ CDMRNetwork::~CDMRNetwork()
 	delete[] m_buffer;
 	delete[] m_salt;
 	delete[] m_id;
+	delete[] m_configData;
 }
 
 void CDMRNetwork::setOptions(const std::string& options)
@@ -87,6 +88,7 @@ void CDMRNetwork::setOptions(const std::string& options)
 
 void CDMRNetwork::setConfig(const unsigned char* data, unsigned int len)
 {
+	delete[] m_configData;
 	m_configData = new unsigned char[len];
 	::memcpy(m_configData, data, len);
 


### PR DESCRIPTION
## Summary
- `m_configData` allocated in `setConfig()` was never freed in the destructor
- Repeated `setConfig()` calls leaked the prior allocation
- Add `delete[]` in destructor and before re-allocation

## Test plan
- Verify config data is still correctly forwarded to networks
- Run with valgrind/ASAN and verify no leaks from CDMRNetwork