### PR TITLE
Add null check for m_mqtt in APRSWriter

### DIFF
--- a/APRSWriter.cpp
+++ b/APRSWriter.cpp
@@ -156,6 +156,7 @@ void CAPRSWriter::sendIdFrame()
 	if (m_debug)
 		LogDebug("APRS ==> %s", output);
 
-	m_mqtt->publish("aprs-gateway/aprs", output);
+	if (m_mqtt != nullptr)
+		m_mqtt->publish("aprs-gateway/aprs", output);
 }
 


### PR DESCRIPTION
## Summary
- APRSWriter dereferences the global `m_mqtt` pointer without checking for null
- Log.cpp already checks `m_mqtt != nullptr` before publishing
- Add the same guard for consistency and safety during shutdown

## Test plan
- Verify APRS messages still publish when MQTT is connected
- Verify no crash during shutdown sequence