### PR TITLE
Fix off-by-one buffer size in DynVoice::linkedTo

### DIFF
--- a/DynVoice.cpp
+++ b/DynVoice.cpp
@@ -137,7 +137,7 @@ bool CDynVoice::open()
 
 void CDynVoice::linkedTo(unsigned int number)
 {
-	char letters[10U];
+	char letters[11U];
 	::sprintf(letters, "%u", number);
 
 	std::vector<std::string> words;


### PR DESCRIPTION
## Summary
- `char letters[10U]` is 1 byte too small for the maximum `unsigned int` string representation (4294967295 = 10 digits + null terminator = 11 bytes)
- Increase to 11 bytes to accommodate all possible values

## Test plan
- Verify voice announcements still work for normal TG numbers