### PR TITLE
Fix uninitialized repeater ID in MMDVM outgoing packets

### DIFF
--- a/MMDVMNetwork.cpp
+++ b/MMDVMNetwork.cpp
@@ -34,7 +34,6 @@ CMMDVMNetwork::CMMDVMNetwork(const std::string& rptAddress, unsigned short rptPo
 m_rptAddr(),
 m_rptAddrLen(0U),
 m_id(0U),
-m_netId(nullptr),
 m_debug(debug),
 m_socket(localAddress, localPort),
 m_buffer(nullptr),
@@ -53,8 +52,6 @@ m_talkerAliasLen(0U)
 		m_rptAddrLen = 0U;
 
 	m_buffer = new unsigned char[BUFFER_LENGTH];
-	m_netId  = new unsigned char[4U];
-
 	m_radioPositionData = new unsigned char[50U];
 	m_talkerAliasData   = new unsigned char[50U];
 
@@ -64,7 +61,6 @@ m_talkerAliasLen(0U)
 
 CMMDVMNetwork::~CMMDVMNetwork()
 {
-	delete[] m_netId;
 	delete[] m_buffer;
 	delete[] m_configData;
 	delete[] m_radioPositionData;
@@ -180,7 +176,10 @@ bool CMMDVMNetwork::write(const CDMRData& data)
 	buffer[9U]  = dstId >> 8;
 	buffer[10U] = dstId >> 0;
 
-	::memcpy(buffer + 11U, m_netId, 4U);
+	buffer[11U] = m_id >> 24;
+	buffer[12U] = m_id >> 16;
+	buffer[13U] = m_id >> 8;
+	buffer[14U] = m_id >> 0;
 
 	unsigned int slotNo = data.getSlotNo();
 

--- a/MMDVMNetwork.h
+++ b/MMDVMNetwork.h
@@ -57,7 +57,6 @@ private:
 	sockaddr_storage           m_rptAddr;
 	unsigned int               m_rptAddrLen;
 	unsigned int               m_id;
-	unsigned char*             m_netId;
 	bool                       m_debug;
 	CUDPSocket                 m_socket;
 	unsigned char*             m_buffer;


### PR DESCRIPTION
## Summary
- `m_netId` (4 bytes) was heap-allocated but never written to
- Every outgoing DMRD packet to the repeater contained uninitialized bytes in the repeater ID field
- Derive the bytes from `m_id` (which is correctly set from incoming DMRC config packets) and remove the unused `m_netId` member entirely

## Test plan
- Capture outgoing packets and verify repeater ID field now matches the configured ID
- Verify MMDVM repeater accepts the corrected packets