### PR TITLE
Validate DMRD packet length before enqueuing

### DIFF
--- a/DMRNetwork.cpp
+++ b/DMRNetwork.cpp
@@ -366,7 +366,7 @@ void CDMRNetwork::clock(unsigned int ms)
 			if (m_debug)
 				CUtils::dump(1U, "Network Received", m_buffer, length);
 
-			if (m_enabled) {
+			if (m_enabled && length == HOMEBREW_DATA_PACKET_LENGTH) {
 				unsigned char len = length;
 				m_rxData.addData(&len, 1U);
 				m_rxData.addData(m_buffer, len);

--- a/MMDVMNetwork.cpp
+++ b/MMDVMNetwork.cpp
@@ -272,9 +272,11 @@ void CMMDVMNetwork::clock(unsigned int ms)
 		CUtils::dump(1U, "Network Received", m_buffer, length);
 
 	if (::memcmp(m_buffer, "DMRD", 4U) == 0) {
-		unsigned char len = length;
-		m_rxData.addData(&len, 1U);
-		m_rxData.addData(m_buffer, len);
+		if (length == HOMEBREW_DATA_PACKET_LENGTH) {
+			unsigned char len = length;
+			m_rxData.addData(&len, 1U);
+			m_rxData.addData(m_buffer, len);
+		}
 	} else if (::memcmp(m_buffer, "DMRG", 4U) == 0) {
 		if (length <= 50U) {
 			::memcpy(m_radioPositionData, m_buffer, length);


### PR DESCRIPTION
## Summary
- Packet length was stored as `unsigned char`, silently wrapping values > 255
- No validation that DMRD packets are the expected 55 bytes
- Add length check before enqueuing in both MMDVMNetwork and DMRNetwork to prevent stale data reads

## Test plan
- Verify normal 55-byte DMRD packets are processed correctly
- Verify oversized or undersized packets are dropped