### PR TITLE
Add DMR trunking support

### DIFF
--- a/Conf.cpp
+++ b/Conf.cpp
@@ -45,6 +45,7 @@ enum class SECTION {
 CConf::CConf(const std::string& file) :
 m_file(file),
 m_daemon(false),
+m_trunkingEnabled(false),
 m_rptAddress("127.0.0.1"),
 m_rptPort(62032U),
 m_localAddress("127.0.0.1"),
@@ -178,6 +179,8 @@ bool CConf::read()
 		if (section == SECTION::GENERAL) {
 			if (::strcmp(key, "Daemon") == 0)
 				m_daemon = ::atoi(value) == 1;
+			else if (::strcmp(key, "TrunkingEnabled") == 0)
+				m_trunkingEnabled = ::atoi(value) == 1;
 			else if (::strcmp(key, "Timeout") == 0)
 				m_rfTimeout = m_netTimeout = (unsigned int)::atoi(value);
 			else if (::strcmp(key, "RFTimeout") == 0)
@@ -431,6 +434,11 @@ bool CConf::read()
 bool CConf::getDaemon() const
 {
 	return m_daemon;
+}
+
+bool CConf::getTrunkingEnabled() const
+{
+	return m_trunkingEnabled;
 }
 
 std::string CConf::getRptAddress() const

--- a/Conf.h
+++ b/Conf.h
@@ -100,6 +100,7 @@ public:
 
 	// The General section
 	bool         getDaemon() const;
+	bool         getTrunkingEnabled() const;
 	unsigned int getRFTimeout() const;
 	unsigned int getNetTimeout() const;
 	std::string  getRptAddress() const;
@@ -193,6 +194,7 @@ public:
 private:
 	std::string  m_file;
 	bool         m_daemon;
+	bool         m_trunkingEnabled;
 	std::string  m_rptAddress;
 	unsigned short m_rptPort;
 	std::string  m_localAddress;

--- a/DMRData.cpp
+++ b/DMRData.cpp
@@ -1,5 +1,6 @@
 /*
  *	Copyright (C) 2015,2016,2017,2025 Jonathan Naylor, G4KLX
+ *	Copyright (C) 2025 Adrian Musceac YO8RZZ
  *
  *	This program is free software; you can redistribute it and/or modify
  *	it under the terms of the GNU General Public License as published by
@@ -32,10 +33,16 @@ m_seqNo(data.m_seqNo),
 m_n(data.m_n),
 m_ber(data.m_ber),
 m_rssi(data.m_rssi),
-m_streamId(data.m_streamId)
+m_streamId(data.m_streamId),
+m_messageSize(data.m_messageSize),
+m_messageFlag(data.m_messageFlag)
 {
 	m_data = new unsigned char[2U * DMR_FRAME_LENGTH_BYTES];
 	::memcpy(m_data, data.m_data, 2U * DMR_FRAME_LENGTH_BYTES);
+	m_uuid = new unsigned char[16U];
+	::memcpy(m_uuid, data.m_uuid, 16U);
+	m_message = new unsigned char[255U];
+	::memcpy(m_message, data.m_message, 255U);
 }
 
 CDMRData::CDMRData() :
@@ -49,20 +56,30 @@ m_seqNo(0U),
 m_n(0U),
 m_ber(0U),
 m_rssi(0U),
-m_streamId(0U)
+m_streamId(0U),
+m_messageSize(0U),
+m_messageFlag(false)
 {
 	m_data = new unsigned char[2U * DMR_FRAME_LENGTH_BYTES];
+	m_uuid = new unsigned char[16U];
+	::memset(m_uuid, 0, 16U);
+	m_message = new unsigned char[255U];
+	::memset(m_message, 0, 255U);
 }
 
 CDMRData::~CDMRData()
 {
 	delete[] m_data;
+	delete[] m_message;
+	delete[] m_uuid;
 }
 
 CDMRData& CDMRData::operator=(const CDMRData& data)
 {
 	if (this != &data) {
 		::memcpy(m_data, data.m_data, DMR_FRAME_LENGTH_BYTES);
+		::memcpy(m_uuid, data.m_uuid, 16U);
+		::memcpy(m_message, data.m_message, 255U);
 
 		m_slotNo   = data.m_slotNo;
 		m_srcId    = data.m_srcId;
@@ -74,6 +91,8 @@ CDMRData& CDMRData::operator=(const CDMRData& data)
 		m_ber      = data.m_ber;
 		m_rssi     = data.m_rssi;
 		m_streamId = data.m_streamId;
+		m_messageFlag = data.m_messageFlag;
+		m_messageSize = data.m_messageSize;
 	}
 
 	return *this;
@@ -195,4 +214,60 @@ unsigned int CDMRData::getStreamId() const
 void CDMRData::setStreamId(unsigned int id)
 {
 	m_streamId = id;
+}
+
+void CDMRData::setUUID(unsigned char *uuid)
+{
+	assert(uuid != nullptr);
+	::memcpy(m_uuid, uuid, 16U);
+}
+
+void CDMRData::getUUID(unsigned char *uuid) const
+{
+	assert(uuid != nullptr);
+	::memcpy(uuid, m_uuid, 16U);
+}
+
+void CDMRData::setMessageSize(unsigned int size)
+{
+	m_messageSize = size;
+}
+
+unsigned int CDMRData::getMessageSize() const
+{
+	return m_messageSize;
+}
+	
+void CDMRData::setMessageFlag(bool is_message)
+{
+	m_messageFlag = is_message;
+	if(!is_message) {
+		::memset(m_message, 0, 255U);
+	}
+}
+
+bool CDMRData::getMessageFlag() const
+{
+	return m_messageFlag;
+}
+	
+bool CDMRData::setMessage(const unsigned char* buffer, unsigned int size)
+{
+	assert(buffer != nullptr);
+	if(size > 255U)
+		return false;
+	::memcpy(m_message, buffer, size);
+	m_messageSize = size;
+	m_messageFlag = true;
+	return true;
+}
+
+unsigned int CDMRData::getMessage(unsigned char* buffer) const
+{
+	assert(buffer != nullptr);
+	if(m_messageFlag) {
+		::memcpy(buffer, m_message, m_messageSize);
+		return m_messageSize;
+	}
+	return 0U;
 }

--- a/DMRData.cpp
+++ b/DMRData.cpp
@@ -237,7 +237,7 @@ unsigned int CDMRData::getMessageSize() const
 {
 	return m_messageSize;
 }
-	
+
 void CDMRData::setMessageFlag(bool is_message)
 {
 	m_messageFlag = is_message;
@@ -250,7 +250,7 @@ bool CDMRData::getMessageFlag() const
 {
 	return m_messageFlag;
 }
-	
+
 bool CDMRData::setMessage(const unsigned char* buffer, unsigned int size)
 {
 	assert(buffer != nullptr);

--- a/DMRData.h
+++ b/DMRData.h
@@ -56,16 +56,16 @@ public:
 
 	void setStreamId(unsigned int id);
 	unsigned int getStreamId() const;
-	
+
 	void setUUID(unsigned char *uuid);
 	void getUUID(unsigned char *uuid) const;
-	
+
 	void setMessageSize(unsigned int size);
 	unsigned int getMessageSize() const;
-	
+
 	void setMessageFlag(bool is_message);
 	bool getMessageFlag() const;
-	
+
 	bool setMessage(const unsigned char* buffer, unsigned int size);
 	unsigned int getMessage(unsigned char* buffer) const;
 

--- a/DMRData.h
+++ b/DMRData.h
@@ -56,6 +56,18 @@ public:
 
 	void setStreamId(unsigned int id);
 	unsigned int getStreamId() const;
+	
+	void setUUID(unsigned char *uuid);
+	void getUUID(unsigned char *uuid) const;
+	
+	void setMessageSize(unsigned int size);
+	unsigned int getMessageSize() const;
+	
+	void setMessageFlag(bool is_message);
+	bool getMessageFlag() const;
+	
+	bool setMessage(const unsigned char* buffer, unsigned int size);
+	unsigned int getMessage(unsigned char* buffer) const;
 
 private:
 	unsigned int   m_slotNo;
@@ -69,6 +81,10 @@ private:
 	unsigned char  m_ber;
 	unsigned char  m_rssi;
 	unsigned int   m_streamId;
+	unsigned char* m_uuid;
+	unsigned char* m_message;
+	unsigned int   m_messageSize;
+	bool           m_messageFlag;
 };
 
 #endif

--- a/DMRGateway.cpp
+++ b/DMRGateway.cpp
@@ -634,7 +634,7 @@ int CDMRGateway::run()
 
 						if (result == PROCESS_RESULT::MATCHED) {
 							slotNo = data.getSlotNo();
-							if (m_trunkingEnabled || m_extStatus[slotNo].m_status == DMRGW_STATUS::NONE || (
+							if (m_trunkingEnabled || (m_extStatus[slotNo].m_status == DMRGW_STATUS::NONE) || (
 									m_extStatus[slotNo].m_status == DMRGW_STATUS::DMRNETWORK &&
 									m_extStatus[slotNo].m_dmrNetwork == i)
 							) {
@@ -665,7 +665,7 @@ int CDMRGateway::run()
 
 						if (result == PROCESS_RESULT::MATCHED) {
 							slotNo = data.getSlotNo();
-							if (m_trunkingEnabled || m_extStatus[slotNo].m_status == DMRGW_STATUS::NONE || (
+							if (m_trunkingEnabled || (m_extStatus[slotNo].m_status == DMRGW_STATUS::NONE) || (
 									m_extStatus[slotNo].m_status == DMRGW_STATUS::DMRNETWORK &&
 									m_extStatus[slotNo].m_dmrNetwork == i)
 							) {
@@ -745,7 +745,7 @@ int CDMRGateway::run()
 					if (rewritten) {
 						// Check that the rewritten slot is free to use.
 						slotNo = data.getSlotNo();
-						if (m_trunkingEnabled || m_extStatus[slotNo].m_status == DMRGW_STATUS::NONE || (
+						if (m_trunkingEnabled || (m_extStatus[slotNo].m_status == DMRGW_STATUS::NONE) || (
 								m_extStatus[slotNo].m_status == DMRGW_STATUS::DMRNETWORK &&
 								m_extStatus[slotNo].m_dmrNetwork == i)
 						) {
@@ -828,7 +828,8 @@ int CDMRGateway::run()
 				timer[i]->stop();
 			}
 		}
-        unsigned int sleep_time = m_trunkingEnabled ? 2U : 10U;
+
+		unsigned int sleep_time = m_trunkingEnabled ? 2U : 10U;
 		if (ms < sleep_time)
 			CThread::sleep(sleep_time);
 	}
@@ -1156,8 +1157,7 @@ bool CDMRGateway::linkXLX(const std::string &number)
 	m_xlxConnected = false;
 	m_xlxRelink.stop();
 
-	m_xlxNetwork = new CDMRNetwork(reflector->m_address, m_xlxPort, m_xlxLocal, m_xlxId, m_xlxPassword, "XLX", false,
-																 m_xlxDebug, m_trunkingEnabled);
+	m_xlxNetwork = new CDMRNetwork(reflector->m_address, m_xlxPort, m_xlxLocal, m_xlxId, m_xlxPassword, "XLX", false, m_xlxDebug, m_trunkingEnabled);
 
 	unsigned char config[400U];
 	unsigned int len = getConfig("XLX", config);

--- a/DMRGateway.cpp
+++ b/DMRGateway.cpp
@@ -1,5 +1,6 @@
 /*
  *   Copyright (C) 2015-2021,2023,2024,2025,2026 by Jonathan Naylor G4KLX
+ *   Copyright (C) 2025,2026 by Adrian Musceac YO8RZZ
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -183,6 +184,7 @@ m_gpsd(nullptr),
 #endif
 m_networkEnabled(nullptr),
 m_networkXlxEnabled(false),
+m_trunkingEnabled(false),
 m_remoteControl(nullptr)
 {
 	CUDPSocket::startup();
@@ -319,6 +321,7 @@ int CDMRGateway::run()
 		m_networkEnabled[i] = m_conf.getDMRNetworkEnabled(i);
 
 	m_networkXlxEnabled = m_conf.getXLXNetworkEnabled();
+	m_trunkingEnabled = m_conf.getTrunkingEnabled();
 
 	m_dmrNetRewrites.resize(m_dmrNetworkCount);
 	m_dmrRFRewrites.resize(m_dmrNetworkCount);
@@ -345,10 +348,10 @@ int CDMRGateway::run()
 		m_configLen = m_repeater->getShortConfig(m_config);
 		if (m_configLen > 0U && m_repeater->getId() > 1000U)
 			break;
+		unsigned int sleep_time = m_trunkingEnabled ? 2U : 10U;
+		m_repeater->clock(sleep_time);
 
-		m_repeater->clock(10U);
-
-		CThread::sleep(10U);
+		CThread::sleep(sleep_time);
 	}
 
 	if (m_killed) {
@@ -517,6 +520,16 @@ int CDMRGateway::run()
 		CDMRData data;
 
 		bool ret = m_repeater->read(data);
+		if(m_trunkingEnabled && data.getMessageFlag()) {
+			for (unsigned int i = 0; i < m_dmrNetworkCount; i++) {
+				if (m_networkEnabled[i] && (m_dmrNetworks[i] != nullptr)) {
+					m_dmrNetworks[i]->write(data);
+				}
+			}
+			ret = false;
+			data.setMessageFlag(false);
+		}
+
 		if (ret) {
 			unsigned int slotNo = data.getSlotNo();
 			unsigned int srcId = data.getSrcId();
@@ -621,7 +634,7 @@ int CDMRGateway::run()
 
 						if (result == PROCESS_RESULT::MATCHED) {
 							slotNo = data.getSlotNo();
-							if (m_extStatus[slotNo].m_status == DMRGW_STATUS::NONE || (
+							if (m_trunkingEnabled || m_extStatus[slotNo].m_status == DMRGW_STATUS::NONE || (
 									m_extStatus[slotNo].m_status == DMRGW_STATUS::DMRNETWORK &&
 									m_extStatus[slotNo].m_dmrNetwork == i)
 							) {
@@ -652,7 +665,7 @@ int CDMRGateway::run()
 
 						if (result == PROCESS_RESULT::MATCHED) {
 							slotNo = data.getSlotNo();
-							if (m_extStatus[slotNo].m_status == DMRGW_STATUS::NONE || (
+							if (m_trunkingEnabled || m_extStatus[slotNo].m_status == DMRGW_STATUS::NONE || (
 									m_extStatus[slotNo].m_status == DMRGW_STATUS::DMRNETWORK &&
 									m_extStatus[slotNo].m_dmrNetwork == i)
 							) {
@@ -698,6 +711,11 @@ int CDMRGateway::run()
 		for (unsigned int i = 0; i < m_dmrNetworkCount; i++) {
 			if (m_networkEnabled[i] && (m_dmrNetworks[i] != nullptr)) {
 				ret = m_dmrNetworks[i]->read(data);
+				if(m_trunkingEnabled && data.getMessageFlag()) {
+					m_repeater->write(data);
+					ret = false;
+					data.setMessageFlag(false);
+				}
 				if (ret) {
 					unsigned int slotNo = data.getSlotNo();
 					unsigned int srcId  = data.getSrcId();
@@ -727,7 +745,7 @@ int CDMRGateway::run()
 					if (rewritten) {
 						// Check that the rewritten slot is free to use.
 						slotNo = data.getSlotNo();
-						if (m_extStatus[slotNo].m_status == DMRGW_STATUS::NONE || (
+						if (m_trunkingEnabled || m_extStatus[slotNo].m_status == DMRGW_STATUS::NONE || (
 								m_extStatus[slotNo].m_status == DMRGW_STATUS::DMRNETWORK &&
 								m_extStatus[slotNo].m_dmrNetwork == i)
 						) {
@@ -810,9 +828,9 @@ int CDMRGateway::run()
 				timer[i]->stop();
 			}
 		}
-
-		if (ms < 10U)
-			CThread::sleep(10U);
+        unsigned int sleep_time = m_trunkingEnabled ? 2U : 10U;
+		if (ms < sleep_time)
+			CThread::sleep(sleep_time);
 	}
 
 	LogInfo("DMRGateway is stopping");
@@ -871,7 +889,7 @@ bool CDMRGateway::createMMDVM()
 	LogInfo("    Local Address: %s", localAddress.c_str());
 	LogInfo("    Local Port: %hu", localPort);
 
-	m_repeater = new CMMDVMNetwork(rptAddress, rptPort, localAddress, localPort, debug);
+	m_repeater = new CMMDVMNetwork(rptAddress, rptPort, localAddress, localPort, debug, m_trunkingEnabled);
 
 	bool ret = m_repeater->open();
 	if (!ret) {
@@ -908,7 +926,7 @@ bool CDMRGateway::createDMRNetwork(unsigned int index)
 		LogInfo("    Local: random");
 	LogInfo("    Location Data: %s", location ? "yes" : "no");
 
-	m_dmrNetworks[index] = new CDMRNetwork(address, port, local, id, password, m_dmrName[index], location, debug);
+	m_dmrNetworks[index] = new CDMRNetwork(address, port, local, id, password, m_dmrName[index], location, debug, m_trunkingEnabled);
 
 	std::string options = m_conf.getDMRNetworkOptions(index);
 
@@ -1138,7 +1156,8 @@ bool CDMRGateway::linkXLX(const std::string &number)
 	m_xlxConnected = false;
 	m_xlxRelink.stop();
 
-	m_xlxNetwork = new CDMRNetwork(reflector->m_address, m_xlxPort, m_xlxLocal, m_xlxId, m_xlxPassword, "XLX", false, m_xlxDebug);
+	m_xlxNetwork = new CDMRNetwork(reflector->m_address, m_xlxPort, m_xlxLocal, m_xlxId, m_xlxPassword, "XLX", false,
+																 m_xlxDebug, m_trunkingEnabled);
 
 	unsigned char config[400U];
 	unsigned int len = getConfig("XLX", config);

--- a/DMRGateway.h
+++ b/DMRGateway.h
@@ -104,6 +104,7 @@ private:
 #endif
 	bool*                  m_networkEnabled;
 	bool                   m_networkXlxEnabled;
+	bool                   m_trunkingEnabled;
 	CRemoteControl*        m_remoteControl;
 
 	bool createMMDVM();

--- a/DMRGateway.ini
+++ b/DMRGateway.ini
@@ -8,6 +8,7 @@ LocalAddress=127.0.0.1
 LocalPort=62031
 RuleTrace=0
 Daemon=0
+TrunkingEnabled=0
 Debug=0
 
 [Log]

--- a/DMRNetwork.cpp
+++ b/DMRNetwork.cpp
@@ -1,5 +1,6 @@
 /*
  *   Copyright (C) 2015,2016,2017,2018,2020,2021,2023,2025 by Jonathan Naylor G4KLX
+ *   Copyright (C) 2025,2026 by Adrian Musceac YO8RZZ
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -29,9 +30,10 @@
 const unsigned int BUFFER_LENGTH = 500U;
 
 const unsigned int HOMEBREW_DATA_PACKET_LENGTH = 55U;
+const unsigned int HOMEBREW_TRUNKING_DATA_PACKET_LENGTH = 71U; // DMRD with 16 byte UUID extension
 
 
-CDMRNetwork::CDMRNetwork(const std::string& address, unsigned short port, unsigned short local, unsigned int id, const std::string& password, const std::string& name, bool location, bool debug) :
+CDMRNetwork::CDMRNetwork(const std::string& address, unsigned short port, unsigned short local, unsigned int id, const std::string& password, const std::string& name, bool location, bool debug, bool trunkingEnabled) :
 m_addr(),
 m_addrLen(0U),
 m_id(nullptr),
@@ -50,7 +52,8 @@ m_rxData(1000U, "DMR Network"),
 m_options(),
 m_configData(nullptr),
 m_configLen(0U),
-m_beacon(false)
+m_beacon(false),
+m_trunkingEnabled(trunkingEnabled)
 {
 	assert(!address.empty());
 	assert(port > 0U);
@@ -137,6 +140,13 @@ bool CDMRNetwork::read(CDMRData& data)
 	m_rxData.getData(&length, 1U);
 	m_rxData.getData(m_buffer, length);
 
+	if ((::memcmp(m_buffer, "DMRT", 4U) == 0) && m_trunkingEnabled) { // DMRT protocol messages
+		if(data.setMessage(m_buffer, length)) {
+			return true;
+		}
+		return false;
+	}
+
 	// Is this a data packet?
 	if (::memcmp(m_buffer, "DMRD", 4U) != 0)
 		return false;
@@ -186,6 +196,13 @@ bool CDMRNetwork::read(CDMRData& data)
 		data.setN(n);
 	}
 
+	if((length == HOMEBREW_TRUNKING_DATA_PACKET_LENGTH) && m_trunkingEnabled) {
+		unsigned char uuid[16];
+		::memset(uuid, 0, 16U);
+		::memcpy(uuid, m_buffer + 55U, 16U);
+		data.setUUID(uuid);
+	}
+
 	return true;
 }
 
@@ -194,8 +211,22 @@ bool CDMRNetwork::write(const CDMRData& data)
 	if (m_status != STATUS::RUNNING)
 		return false;
 
-	unsigned char buffer[HOMEBREW_DATA_PACKET_LENGTH];
-	::memset(buffer, 0x00U, HOMEBREW_DATA_PACKET_LENGTH);
+	if(data.getMessageFlag() && m_trunkingEnabled) { // used by the DMRT protocol messages
+		unsigned int message_size = data.getMessageSize();
+		if ((message_size < 1U) || (message_size > 255U))
+			return false;
+		unsigned char buffer[255U];
+		::memset(buffer, 0x00U, 255U);
+		unsigned int length = data.getMessage(buffer);
+		if (m_debug)
+			CUtils::dump(1U, "Message to Network Transmitted", buffer, length);
+
+		write(buffer, length);
+		return true;
+	}
+	const unsigned int buffer_size = m_trunkingEnabled ? HOMEBREW_TRUNKING_DATA_PACKET_LENGTH : HOMEBREW_DATA_PACKET_LENGTH;
+	unsigned char buffer[HOMEBREW_TRUNKING_DATA_PACKET_LENGTH];
+	::memset(buffer, 0x00U, HOMEBREW_TRUNKING_DATA_PACKET_LENGTH);
 
 	buffer[0U]  = 'D';
 	buffer[1U]  = 'M';
@@ -241,7 +272,13 @@ bool CDMRNetwork::write(const CDMRData& data)
 
 	buffer[54U] = data.getRSSI();
 
-	write(buffer, HOMEBREW_DATA_PACKET_LENGTH);
+	if(m_trunkingEnabled) {
+		unsigned char uuid[16U];
+		data.getUUID(uuid);
+		::memcpy(buffer + 55U, uuid, 16U);
+	}
+
+	write(buffer, buffer_size);
 
 	return true;
 }
@@ -296,8 +333,10 @@ bool CDMRNetwork::writeHomePosition(float latitude, float longitude)
 		return false;
 
 	char buffer[50U];
-
-	::memcpy(buffer + 0U, "RPTG", 4U);
+	if(m_trunkingEnabled)
+		::memcpy(buffer + 0U, "DTCG", 4U);
+	else
+		::memcpy(buffer + 0U, "RPTG", 4U);
 
 	::memcpy(buffer + 4U, m_id, 4U);
 
@@ -322,7 +361,10 @@ void CDMRNetwork::close(bool sayGoodbye)
 
 	if (sayGoodbye && (m_status == STATUS::RUNNING)) {
 		unsigned char buffer[9U];
-		::memcpy(buffer + 0U, "RPTCL", 5U);
+		if(m_trunkingEnabled)
+			::memcpy(buffer + 0U, "DTCCL", 5U);
+		else
+			::memcpy(buffer + 0U, "RPTCL", 5U);
 		::memcpy(buffer + 5U, m_id, 4U);
 		write(buffer, 9U);
 	}
@@ -364,11 +406,15 @@ void CDMRNetwork::clock(unsigned int ms)
 		CUtils::dump(1U, "Network Received", m_buffer, length);
 
 	if (length > 0 && CUDPSocket::match(m_addr, address)) {
-		if (::memcmp(m_buffer, "DMRD", 4U) == 0) {
+		if ((::memcmp(m_buffer, "DMRT", 4U) == 0) && (length <= 255) && m_trunkingEnabled && m_enabled) {
+			unsigned char len = length;
+			m_rxData.addData(&len, 1U);
+			m_rxData.addData(m_buffer, len);
+		} else if (::memcmp(m_buffer, "DMRD", 4U) == 0) {
 			if (m_debug)
 				CUtils::dump(1U, "Network Received", m_buffer, length);
 
-			if (m_enabled && length == HOMEBREW_DATA_PACKET_LENGTH) {
+			if (m_enabled && ((length == HOMEBREW_DATA_PACKET_LENGTH) || (length == HOMEBREW_TRUNKING_DATA_PACKET_LENGTH))) {
 				unsigned char len = length;
 				m_rxData.addData(&len, 1U);
 				m_rxData.addData(m_buffer, len);
@@ -439,6 +485,98 @@ void CDMRNetwork::clock(unsigned int ms)
 			m_timeoutTimer.start();
 		} else if (::memcmp(m_buffer, "RPTSBKN", 7U) == 0) {
 			m_beacon = true;
+		} else if ((::memcmp(m_buffer, "DTCNAK",  6U) == 0) && m_trunkingEnabled) {
+			if (m_status == STATUS::RUNNING) {
+				LogWarning("%s, Login to the master via DTC protocol has failed, retrying login ...", m_name.c_str());
+				m_status = STATUS::WAITING_LOGIN;
+				m_timeoutTimer.start();
+				m_retryTimer.start();
+			} else {
+				/* Once the modem death spiral has been prevented in Modem.cpp
+				   the Network sometimes times out and reaches here.
+				   We want it to reconnect so... */
+				LogError("%s, Login to the master via DTC protocol has failed, retrying network ...", m_name.c_str());
+				close(false);
+				open();
+				return;
+			}
+		} else if ((::memcmp(m_buffer, "DTCACK",  6U) == 0) && m_trunkingEnabled) {
+			switch (m_status) {
+				case STATUS::WAITING_LOGIN:
+					LogDebug("%s, Sending DTC authorisation", m_name.c_str());
+					::memcpy(m_salt, m_buffer + 6U, sizeof(uint32_t));
+					writeAuthorisation();
+					m_status = STATUS::WAITING_AUTHORISATION;
+					m_timeoutTimer.start();
+					m_retryTimer.start();
+					break;
+				case STATUS::WAITING_AUTHORISATION:
+					LogDebug("%s, Sending DTC configuration", m_name.c_str());
+					writeConfig();
+					m_status = STATUS::WAITING_CONFIG;
+					m_timeoutTimer.start();
+					m_retryTimer.start();
+					break;
+				case STATUS::WAITING_CONFIG:
+				{
+					if (m_options.empty()) {
+						LogMessage("%s, Logged into the master via DTC protocol successfully", m_name.c_str());
+						m_status = STATUS::RUNNING;
+						const unsigned char len = 5U;
+						unsigned char msg_buffer[len];
+						msg_buffer[0U] = 'D';
+						msg_buffer[1U] = 'M';
+						msg_buffer[2U] = 'R';
+						msg_buffer[3U] = 'T';
+						msg_buffer[4U] = 0xC1;
+						m_rxData.addData(&len, 1U);
+						m_rxData.addData(msg_buffer, len);
+					} else {
+						LogDebug("%s, Sending DTC options", m_name.c_str());
+						writeOptions();
+						m_status = STATUS::WAITING_OPTIONS;
+					}
+					m_timeoutTimer.start();
+					m_retryTimer.start();
+					break;
+				}
+				case STATUS::WAITING_OPTIONS:
+				{
+					LogMessage("%s, Logged into the master via DTC protocol successfully", m_name.c_str());
+					m_status = STATUS::RUNNING;
+					const unsigned char len = 5U;
+					unsigned char msg_buffer[len];
+					msg_buffer[0U] = 'D';
+					msg_buffer[1U] = 'M';
+					msg_buffer[2U] = 'R';
+					msg_buffer[3U] = 'T';
+					msg_buffer[4U] = 0xC1;
+					m_rxData.addData(&len, 1U);
+					m_rxData.addData(msg_buffer, len);
+					m_timeoutTimer.start();
+					m_retryTimer.start();
+					break;
+				}
+				default:
+					break;
+			}
+		} else if ((::memcmp(m_buffer, "DTCCL",   5U) == 0) && m_trunkingEnabled) {
+			LogError("%s, Master is closing down", m_name.c_str());
+			const unsigned char len = 5U;
+			unsigned char msg_buffer[len];
+			msg_buffer[0U] = 'D';
+			msg_buffer[1U] = 'M';
+			msg_buffer[2U] = 'R';
+			msg_buffer[3U] = 'T';
+			msg_buffer[4U] = 0xC2;
+			m_rxData.addData(&len, 1U);
+			m_rxData.addData(msg_buffer, len);
+			close(false);
+			open();
+		} else if ((::memcmp(m_buffer, "DTCPONG", 7U) == 0) && m_trunkingEnabled) {
+			m_timeoutTimer.start();
+		} else if ((::memcmp(m_buffer, "DTCSBKN", 7U) == 0) && m_trunkingEnabled) {
+			m_beacon = true;
 		} else {
 			char buffer[100U];
 			::sprintf(buffer, "%s, Unknown packet from the master", m_name.c_str());
@@ -483,8 +621,10 @@ void CDMRNetwork::clock(unsigned int ms)
 bool CDMRNetwork::writeLogin()
 {
 	unsigned char buffer[8U];
-
-	::memcpy(buffer + 0U, "RPTL", 4U);
+	if(m_trunkingEnabled)
+		::memcpy(buffer + 0U, "DTCL", 4U);
+	else
+		::memcpy(buffer + 0U, "RPTL", 4U);
 	::memcpy(buffer + 4U, m_id, 4U);
 
 	return write(buffer, 8U);
@@ -500,7 +640,10 @@ bool CDMRNetwork::writeAuthorisation()
 		in[i + sizeof(uint32_t)] = m_password.at(i);
 
 	unsigned char out[40U];
-	::memcpy(out + 0U, "RPTK", 4U);
+	if(m_trunkingEnabled)
+		::memcpy(out + 0U, "DTCK", 4U);
+	else
+		::memcpy(out + 0U, "RPTK", 4U);
 	::memcpy(out + 4U, m_id, 4U);
 
 	CSHA256 sha256;
@@ -514,8 +657,10 @@ bool CDMRNetwork::writeAuthorisation()
 bool CDMRNetwork::writeOptions()
 {
 	char buffer[300U];
-
-	::memcpy(buffer + 0U, "RPTO", 4U);
+	if(m_trunkingEnabled)
+		::memcpy(buffer + 0U, "DTCO", 4U);
+	else
+		::memcpy(buffer + 0U, "RPTO", 4U);
 	::memcpy(buffer + 4U, m_id, 4U);
 	::strcpy(buffer + 8U, m_options.c_str());
 
@@ -525,8 +670,10 @@ bool CDMRNetwork::writeOptions()
 bool CDMRNetwork::writeConfig()
 {
 	char buffer[400U];
-
-	::memcpy(buffer + 0U, "RPTC", 4U);
+	if(m_trunkingEnabled)
+		::memcpy(buffer + 0U, "DTCC", 4U);
+	else
+		::memcpy(buffer + 0U, "RPTC", 4U);
 	::memcpy(buffer + 4U, m_id, 4U);
 	::memcpy(buffer + 8U, m_configData, m_configLen);
 
@@ -539,8 +686,10 @@ bool CDMRNetwork::writeConfig()
 bool CDMRNetwork::writePing()
 {
 	unsigned char buffer[11U];
-
-	::memcpy(buffer + 0U, "RPTPING", 7U);
+	if(m_trunkingEnabled)
+		::memcpy(buffer + 0U, "DTCPING", 7U);
+	else
+		::memcpy(buffer + 0U, "RPTPING", 7U);
 	::memcpy(buffer + 7U, m_id, 4U);
 
 	return write(buffer, 11U);

--- a/DMRNetwork.h
+++ b/DMRNetwork.h
@@ -30,7 +30,7 @@
 class CDMRNetwork
 {
 public:
-	CDMRNetwork(const std::string& address, unsigned short port, unsigned short local, unsigned int id, const std::string& password, const std::string& name, bool location, bool debug);
+	CDMRNetwork(const std::string& address, unsigned short port, unsigned short local, unsigned int id, const std::string& password, const std::string& name, bool location, bool debug, bool trunkingEnabled);
 	~CDMRNetwork();
 
 	void setOptions(const std::string& options);
@@ -94,6 +94,7 @@ private:
 	unsigned int   m_configLen;
 
 	bool           m_beacon;
+	bool           m_trunkingEnabled;
 
 	bool writeLogin();
 	bool writeAuthorisation();

--- a/MMDVMNetwork.cpp
+++ b/MMDVMNetwork.cpp
@@ -106,7 +106,7 @@ bool CMMDVMNetwork::read(CDMRData& data)
 
 	m_rxData.getData(&length, 1U);
 	m_rxData.getData(m_buffer, length);
-	
+
 	if ((::memcmp(m_buffer, "DMRT", 4U) == 0) && m_trunkingEnabled) { // DMRT protocol message
 		if(data.setMessage(m_buffer, length)) {
 			return true;
@@ -162,7 +162,7 @@ bool CMMDVMNetwork::read(CDMRData& data)
 		data.setDataType(DT_VOICE);
 		data.setN(n);
 	}
-	
+
 	if((length == HOMEBREW_TRUNKING_DATA_PACKET_LENGTH) && m_trunkingEnabled) {
 		unsigned char uuid[16];
 		::memset(uuid, 0, 16U);
@@ -238,7 +238,7 @@ bool CMMDVMNetwork::write(const CDMRData& data)
 	buffer[53U] = data.getBER();
 
 	buffer[54U] = data.getRSSI();
-	
+
 	if(m_trunkingEnabled) {
 		unsigned char uuid[16U];
 		data.getUUID(uuid);

--- a/MMDVMNetwork.cpp
+++ b/MMDVMNetwork.cpp
@@ -1,5 +1,6 @@
 /*
  *   Copyright (C) 2015,2016,2017,2018,2020,2025 by Jonathan Naylor G4KLX
+ *   Copyright (C) 2025,2026 by Adrian Musceac YO8RZZ
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -28,13 +29,15 @@
 const unsigned int BUFFER_LENGTH = 500U;
 
 const unsigned int HOMEBREW_DATA_PACKET_LENGTH = 55U;
+const unsigned int HOMEBREW_TRUNKING_DATA_PACKET_LENGTH = 71U; // DMRD with 16 byte UUID extension
 
 
-CMMDVMNetwork::CMMDVMNetwork(const std::string& rptAddress, unsigned short rptPort, const std::string& localAddress, unsigned short localPort, bool debug) :
+CMMDVMNetwork::CMMDVMNetwork(const std::string& rptAddress, unsigned short rptPort, const std::string& localAddress, unsigned short localPort, bool debug, bool trunkingEnabled) :
 m_rptAddr(),
 m_rptAddrLen(0U),
 m_id(0U),
 m_debug(debug),
+m_trunkingEnabled(trunkingEnabled),
 m_socket(localAddress, localPort),
 m_buffer(nullptr),
 m_rxData(1000U, "MMDVM Network"),
@@ -103,6 +106,13 @@ bool CMMDVMNetwork::read(CDMRData& data)
 
 	m_rxData.getData(&length, 1U);
 	m_rxData.getData(m_buffer, length);
+	
+	if ((::memcmp(m_buffer, "DMRT", 4U) == 0) && m_trunkingEnabled) { // DMRT protocol message
+		if(data.setMessage(m_buffer, length)) {
+			return true;
+		}
+		return false;
+	}
 
 	// Is this a data packet?
 	if (::memcmp(m_buffer, "DMRD", 4U) != 0)
@@ -152,14 +162,35 @@ bool CMMDVMNetwork::read(CDMRData& data)
 		data.setDataType(DT_VOICE);
 		data.setN(n);
 	}
+	
+	if((length == HOMEBREW_TRUNKING_DATA_PACKET_LENGTH) && m_trunkingEnabled) {
+		unsigned char uuid[16];
+		::memset(uuid, 0, 16U);
+		::memcpy(uuid, m_buffer + 55U, 16U);
+		data.setUUID(uuid);
+	}
 
 	return true;
 }
 
 bool CMMDVMNetwork::write(const CDMRData& data)
 {
-	unsigned char buffer[HOMEBREW_DATA_PACKET_LENGTH];
-	::memset(buffer, 0x00U, HOMEBREW_DATA_PACKET_LENGTH);
+	if(data.getMessageFlag() && m_trunkingEnabled) {
+		const unsigned int message_size = data.getMessageSize();
+		if((message_size < 1U) || (message_size > 255U))
+			return false;
+		unsigned char buffer[255U];
+		::memset(buffer, 0x00U, 255U);
+		unsigned int length = data.getMessage(buffer);
+		if (m_debug)
+			CUtils::dump(1U, "Network Transmitted", buffer, length);
+
+		m_socket.write(buffer, length, m_rptAddr, m_rptAddrLen);
+		return true;
+	}
+	const unsigned int buffer_size = m_trunkingEnabled ? HOMEBREW_TRUNKING_DATA_PACKET_LENGTH : HOMEBREW_DATA_PACKET_LENGTH;
+	unsigned char buffer[HOMEBREW_TRUNKING_DATA_PACKET_LENGTH];
+	::memset(buffer, 0x00U, HOMEBREW_TRUNKING_DATA_PACKET_LENGTH);
 
 	buffer[0U]  = 'D';
 	buffer[1U]  = 'M';
@@ -207,11 +238,17 @@ bool CMMDVMNetwork::write(const CDMRData& data)
 	buffer[53U] = data.getBER();
 
 	buffer[54U] = data.getRSSI();
+	
+	if(m_trunkingEnabled) {
+		unsigned char uuid[16U];
+		data.getUUID(uuid);
+		::memcpy(buffer + 55U, uuid, 16U);
+	}
 
 	if (m_debug)
-		CUtils::dump(1U, "Network Transmitted", buffer, HOMEBREW_DATA_PACKET_LENGTH);
+		CUtils::dump(1U, "Network Transmitted", buffer, buffer_size);
 
-	m_socket.write(buffer, HOMEBREW_DATA_PACKET_LENGTH, m_rptAddr, m_rptAddrLen);
+	m_socket.write(buffer, buffer_size, m_rptAddr, m_rptAddrLen);
 
 	return true;
 }
@@ -270,8 +307,12 @@ void CMMDVMNetwork::clock(unsigned int ms)
 	if (m_debug)
 		CUtils::dump(1U, "Network Received", m_buffer, length);
 
-	if (::memcmp(m_buffer, "DMRD", 4U) == 0) {
-		if (length == HOMEBREW_DATA_PACKET_LENGTH) {
+	if ((::memcmp(m_buffer, "DMRT", 4U) == 0) && (length <= 255) && m_trunkingEnabled) {
+		unsigned char len = length;
+		m_rxData.addData(&len, 1U);
+		m_rxData.addData(m_buffer, len);
+	} else if (::memcmp(m_buffer, "DMRD", 4U) == 0) {
+		if ((length == HOMEBREW_DATA_PACKET_LENGTH) || (length == HOMEBREW_TRUNKING_DATA_PACKET_LENGTH)) {
 			unsigned char len = length;
 			m_rxData.addData(&len, 1U);
 			m_rxData.addData(m_buffer, len);

--- a/MMDVMNetwork.h
+++ b/MMDVMNetwork.h
@@ -30,7 +30,7 @@
 class CMMDVMNetwork
 {
 public:
-	CMMDVMNetwork(const std::string& rptAddress, unsigned short rptPort, const std::string& localAddress, unsigned short localPort, bool debug, bool trunkingProtocol);
+	CMMDVMNetwork(const std::string& rptAddress, unsigned short rptPort, const std::string& localAddress, unsigned short localPort, bool debug, bool trunkingEnabled);
 	~CMMDVMNetwork();
 
 	unsigned int getShortConfig(unsigned char* config) const;

--- a/MMDVMNetwork.h
+++ b/MMDVMNetwork.h
@@ -30,7 +30,7 @@
 class CMMDVMNetwork
 {
 public:
-	CMMDVMNetwork(const std::string& rptAddress, unsigned short rptPort, const std::string& localAddress, unsigned short localPort, bool debug);
+	CMMDVMNetwork(const std::string& rptAddress, unsigned short rptPort, const std::string& localAddress, unsigned short localPort, bool debug, bool trunkingProtocol);
 	~CMMDVMNetwork();
 
 	unsigned int getShortConfig(unsigned char* config) const;
@@ -58,6 +58,7 @@ private:
 	unsigned int               m_rptAddrLen;
 	unsigned int               m_id;
 	bool                       m_debug;
+	bool                       m_trunkingEnabled;
 	CUDPSocket                 m_socket;
 	unsigned char*             m_buffer;
 	CRingBuffer<unsigned char> m_rxData;


### PR DESCRIPTION
This change enables more than one talkgroup be active at the same time on one timeslot of a network connection, and adds support for the Homebrew DMR trunking protocol implemented by Brandmeister and documented at https://github.com/qradiolink/dmrtc/blob/master/docs/Homebrew_DMR_trunking_protocol_v0.6.pdf

Enabling the new functionality is controlled by the config setting TrunkingEnabled