### PR TITLE
Fix typo in QRG keywords

### DIFF
--- a/DMRGateway.ini
+++ b/DMRGateway.ini
@@ -24,8 +24,8 @@ Directory=./Audio
 
 [Info]
 Callsign=G9BF
-TXFRequency=435000000
-RXFRequency=435000000
+TXFrequency=435000000
+RXFrequency=435000000
 Power=1
 ColorCode=1
 Duplex=1


### PR DESCRIPTION
Fix for issue #153 

Corrects wrong capital letter in TXFrequency / RXFrequency which causes invalid RPTC messages (QRG entries missing in msg).