### PR TITLE
Publish MQTT link events for DMR network connect/disconnect

### DIFF
--- a/DMRGateway.cpp
+++ b/DMRGateway.cpp
@@ -450,6 +450,7 @@ int CDMRGateway::run()
 				}
 
 				m_xlxConnected = true;
+				writeJSONLink("XLX" + m_xlxNumber, true);
 
 				if (m_xlxNumber == m_xlxStartup && m_xlxRoom == m_xlxReflector)
 					m_xlxRelink.stop();
@@ -462,6 +463,7 @@ int CDMRGateway::run()
 					m_xlxVoice->unlinked();
 
 				m_xlxConnected = false;
+				writeJSONLink("XLX" + m_xlxNumber, false);
 				m_xlxRelink.stop();
 			} else if (connected && m_xlxRelink.isRunning() && m_xlxRelink.hasExpired()) {
 				m_xlxRelink.stop();
@@ -1145,6 +1147,9 @@ bool CDMRGateway::linkXLX(const std::string &number)
 		delete m_xlxNetwork;
 	}
 
+	if (m_xlxConnected)
+		writeJSONLink("XLX" + m_xlxNumber, false);
+
 	m_xlxConnected = false;
 	m_xlxRelink.stop();
 
@@ -1182,6 +1187,9 @@ void CDMRGateway::unlinkXLX()
 		delete m_xlxNetwork;
 		m_xlxNetwork = nullptr;
 	}
+
+	if (m_xlxConnected)
+		writeJSONLink("XLX" + m_xlxNumber, false);
 
 	m_xlxConnected = false;
 	m_xlxRelink.stop();

--- a/DMRGateway.cpp
+++ b/DMRGateway.cpp
@@ -147,6 +147,7 @@ m_repeater(nullptr),
 m_dmrNetworkCount(0U),
 m_dmrNetworks(),
 m_dmrName(),
+m_dmrNetworkStatus(),
 m_xlxReflectors(nullptr),
 m_xlxNetwork(nullptr),
 m_xlxId(0U),
@@ -316,6 +317,7 @@ int CDMRGateway::run()
 
 	m_dmrNetworks.resize(m_dmrNetworkCount, nullptr);
 	m_dmrName.resize(m_dmrNetworkCount, "");
+	m_dmrNetworkStatus.resize(m_dmrNetworkCount, false);
 	m_networkEnabled = new bool[m_dmrNetworkCount];
 
 	for (unsigned int i = 0; i < m_dmrNetworkCount; i++)
@@ -777,9 +779,17 @@ int CDMRGateway::run()
 
 		m_xlxRelink.clock(ms);
 
-		for (unsigned int i = 0; i < m_dmrNetworkCount; i++)
-			if (m_dmrNetworks[i] != nullptr)
+		for (unsigned int i = 0; i < m_dmrNetworkCount; i++) {
+			if (m_dmrNetworks[i] != nullptr) {
 				m_dmrNetworks[i]->clock(ms);
+
+				bool connected = m_dmrNetworks[i]->isConnected();
+				if (connected != m_dmrNetworkStatus[i]) {
+					m_dmrNetworkStatus[i] = connected;
+					writeJSONLink(m_dmrName[i], connected);
+				}
+			}
+		}
 
 		if (m_xlxNetwork != nullptr)
 			m_xlxNetwork->clock(ms);
@@ -1523,6 +1533,18 @@ void CDMRGateway::buildNetworkStatusString(std::string &str)
 void CDMRGateway::buildNetworkStatusNetworkString(std::string &str, const std::string& name, CDMRNetwork* network, bool enabled)
 {
 	str += name + ":"+ (((network == nullptr) || (enabled == false)) ? "n/a" : (network->isConnected() ? "conn" : "disc"));
+}
+
+void CDMRGateway::writeJSONLink(const std::string& name, bool connected)
+{
+	nlohmann::json json;
+
+	json["timestamp"] = CUtils::createTimestamp();
+	json["action"]    = connected ? "linking" : "unlinked";
+	json["reason"]    = "network";
+	json["network"]   = name;
+
+	WriteJSON("link", json, true);
 }
 
 void CDMRGateway::buildNetworkHostsString(std::string &str)

--- a/DMRGateway.h
+++ b/DMRGateway.h
@@ -67,6 +67,7 @@ private:
 	unsigned int       m_dmrNetworkCount;
 	std::vector<CDMRNetwork*> m_dmrNetworks;
 	std::vector<std::string> m_dmrName;
+	std::vector<bool>  m_dmrNetworkStatus;
 	CReflectors*       m_xlxReflectors;
 	CDMRNetwork*       m_xlxNetwork;
 	unsigned int       m_xlxId;
@@ -126,6 +127,7 @@ private:
 	void processEnableCommand(CDMRNetwork* network, const std::string& name, bool& mode, bool enabled);
 	void buildNetworkStatusNetworkString(std::string &str, const std::string& name, CDMRNetwork* network, bool enabled);
 	void buildNetworkHostNetworkString(std::string &str, const std::string& name, CDMRNetwork* network);
+	void writeJSONLink(const std::string& name, bool connected);
 
 	static void onCommand(const unsigned char* message, unsigned int length);
 	static void onDynamic(const unsigned char* message, unsigned int length);

--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,9 @@
 {
 	"$defs": {
-		"timestamp": {"type": "string"}
+		"timestamp": {"type": "string"},
+		"network": {"type": "string"},
+		"action": {"type": "string", "enum": ["linking", "unlinked"]},
+		"reason": {"type": "string", "enum": ["network"]}
 	},
 
 	"status": {
@@ -8,6 +11,15 @@
 		"timestamp": {"$ref": "#/$defs/timestamp"},
 		"message": {"type": "string"},
 		"required": ["timestamp", "message"]
+	},
+
+	"link": {
+		"type": "object",
+		"timestamp": {"$ref": "#/$defs/timestamp"},
+		"action": {"$ref": "#/$defs/action"},
+		"reason": {"$ref": "#/$defs/reason"},
+		"network": {"$ref": "#/$defs/network"},
+		"required": ["timestamp", "action", "network"]
 	}
 }
 


### PR DESCRIPTION
Each configured DMR network already tracks its own connection state via CDMRNetwork::isConnected(). The main loop now polls it once per network per cycle and publishes a link event on the dmr-gateway/json MQTT topic whenever it changes, matching the pattern already used by YSFGateway/P25Gateway/NXDNGateway:

  `{"link": {"timestamp": "...", "action": "linking"|"unlinked", "reason": "network", "network": "<Name>"}}`

network is each connection's configured Name= from its [DMR Network N] section. Updated schema.json to document the new event.